### PR TITLE
Added Hardtanh activation function

### DIFF
--- a/dsp/dsp.cpp
+++ b/dsp/dsp.cpp
@@ -205,6 +205,11 @@ inline float fast_tanh_(const float x) {
            (2.44506634652299f + x2) * fabs(x + 0.814642734961073f * x * ax)));
 }
 
+inline float hard_tanh_(const float x) {
+    const float t = x < -1 ? -1 : x;
+    return t > 1 ? 1 : t;
+}
+
 void tanh_(Eigen::MatrixXf &x, const long i_start, const long i_end,
            const long j_start, const long j_end) {
   for (long j = j_start; j < j_end; j++)
@@ -225,6 +230,27 @@ void tanh_(Eigen::MatrixXf &x) {
   for (long pos = 0; pos < size; pos++) {
     ptr[pos] = tanh_impl_(ptr[pos]);
   }
+}
+
+void hard_tanh_(Eigen::MatrixXf& x, const long i_start, const long i_end,
+    const long j_start, const long j_end) {
+    for (long j = j_start; j < j_end; j++)
+        for (long i = i_start; i < i_end; i++)
+            x(i, j) = hard_tanh_(x(i, j));
+}
+
+void hard_tanh_(Eigen::MatrixXf& x, const long j_start, const long j_end) {
+    hard_tanh_(x, 0, x.rows(), j_start, j_end);
+}
+
+void hard_tanh_(Eigen::MatrixXf& x) {
+    float* ptr = x.data();
+
+    long size = x.rows() * x.cols();
+
+    for (long pos = 0; pos < size; pos++) {
+        ptr[pos] = hard_tanh_(ptr[pos]);
+    }
 }
 
 void Conv1D::set_params_(std::vector<float>::iterator &params) {

--- a/dsp/dsp.h
+++ b/dsp/dsp.h
@@ -153,6 +153,14 @@ void tanh_(Eigen::MatrixXf &x, const long i_start, const long i_end);
 
 void tanh_(Eigen::MatrixXf &x);
 
+// In-place Hardtanh on (N,M) array
+void hard_tanh_(Eigen::MatrixXf& x, const long i_start, const long i_end,
+    const long j_start, const long j_end);
+// Subset of the columns
+void hard_tanh_(Eigen::MatrixXf& x, const long i_start, const long i_end);
+
+void hard_tanh_(Eigen::MatrixXf& x);
+
 class Conv1D {
 public:
   Conv1D() { this->_dilation = 1; };

--- a/dsp/wavenet.cpp
+++ b/dsp/wavenet.cpp
@@ -30,7 +30,9 @@ void wavenet::_Layer::process_(const Eigen::MatrixXf &input,
   this->_conv.process_(input, this->_z, i_start, ncols, 0);
   // Mix-in condition
   this->_z += this->_input_mixin.process(condition);
-  if (this->_activation == "Tanh")
+  if (this->_activation == "Hardtanh")
+      hard_tanh_(this->_z);
+  else if (this->_activation == "Tanh")
     tanh_(this->_z);
   else if (this->_activation == "ReLU")
     relu_(this->_z, 0, channels, 0, this->_z.cols());


### PR DESCRIPTION
This adds support for the "Hardtanh" activation function in WaveNet models. It will have no impact on current models.

My (admittedly limited so far) testing indicates that using a hard tanh activation function (basically clamp to -1/1) results in the same ESR as using a regular tanh. But it is ***much*** faster to compute.

It seems to perform about the same as the fast tanh function that is currently disabled, but might be able to be further optimized with SSE magic. It also has the benefit of being available as an activation fuction in pytorch.

If we get it implemented here, now - once it has been out in the wild for a bit we can switch to using it in training (maybe by default, maybe an option, maybe only on lite/feather?)

If you want to test training a model with it, just swap out "Tanh" for "Hardtanh" (**lowercase "t"**) in the WaveNet layer config.