### PR TITLE
fabs->fabsf in fast tanh

### DIFF
--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -205,14 +205,14 @@ void sigmoid_(Eigen::MatrixXf &x, const long i_start, const long i_end,
 }
 
 inline float fast_tanh_(const float x) {
-  const float ax = fabs(x);
+  const float ax = fabsf(x);
   const float x2 = x * x;
 
   return (x *
           (2.45550750702956f + 2.45550750702956f * ax +
            (0.893229853513558f + 0.821226666969744f * ax) * x2) /
           (2.44506634652299f +
-           (2.44506634652299f + x2) * fabs(x + 0.814642734961073f * x * ax)));
+           (2.44506634652299f + x2) * fabsf(x + 0.814642734961073f * x * ax)));
 }
 
 inline float hard_tanh_(const float x) {


### PR DESCRIPTION
This makes sure we don't get double promotion in the fast tanh function.

I suspect that fast tanh will be superseded by hard tanh before it sees the light of day, but just in case...