### PR TITLE
Activation constructor/destructor cleanup

### DIFF
--- a/NAM/activations.h
+++ b/NAM/activations.h
@@ -74,7 +74,6 @@ class ActivationTanh : public Activation
 class ActivationHardTanh : public Activation
 {
   public:
-    ActivationHardTanh(){};
     void apply(float* data, long size) override
     {
       for (long pos = 0; pos < size; pos++)
@@ -87,7 +86,6 @@ class ActivationHardTanh : public Activation
 class ActivationFastTanh : public Activation
 {
   public:
-    ActivationFastTanh(){};
     void apply(float* data, long size) override
     {
       for (long pos = 0; pos < size; pos++)
@@ -100,7 +98,6 @@ class ActivationFastTanh : public Activation
 class ActivationReLU : public Activation
 {
   public:
-    ActivationReLU(){};
     void apply(float* data, long size) override
     {
       for (long pos = 0; pos < size; pos++)
@@ -113,7 +110,6 @@ class ActivationReLU : public Activation
 class ActivationSigmoid : public Activation
 {
   public:
-    ActivationSigmoid(){};
     void apply(float* data, long size) override
     {
       for (long pos = 0; pos < size; pos++)

--- a/NAM/activations.h
+++ b/NAM/activations.h
@@ -35,7 +35,8 @@ return (x * (2.45550750702956f + 2.45550750702956f * ax + (0.893229853513558f + 
 class Activation
 {
 public:
-Activation(){};
+  Activation() = default;
+  virtual ~Activation() = default;
   virtual void apply(Eigen::MatrixXf& matrix)
   {
     apply(matrix.data(), matrix.rows() * matrix.cols());


### PR DESCRIPTION
This PR just cleans up the Activation class constructor/destructors. It wasn't currently a problem (although it could have been in the future), but it gits rid of a bunch of annoying compiler warnings.