### PR TITLE
Method to determine whether model has loudness data

### DIFF
--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -60,6 +60,7 @@ public:
   //   DSP subclass implementation.
   virtual void finalize_(const int num_frames);
   void SetNormalize(const bool normalize) { this->mNormalizeOutputLoudness = normalize; };
+  bool HasLoudness() { return mLoudness != TARGET_DSP_LOUDNESS; };
 
 protected:
   // How loud is the model?


### PR DESCRIPTION
Adding method determining whether model has configured loudness parameter. If current loudness is equal to the default one - normalisation wont occur. This is a compromise to avoid passing unnecessary bool param to the model.

(partially) Fixes sdatkinson/NeuralAmpModelerPlugin#183

This is a first of 2 parts to resolve ☝️ issue. 
