### PR TITLE
DSPs prepared for loading persisted models

### DIFF
--- a/dsp/ImpulseResponse.cpp
+++ b/dsp/ImpulseResponse.cpp
@@ -25,6 +25,14 @@ dsp::ImpulseResponse::ImpulseResponse(const char* fileName, const double sampleR
     this->_SetWeights(sampleRate);
 }
 
+dsp::ImpulseResponse::ImpulseResponse(const IRData& irData, const double sampleRate)
+: mWavState(dsp::wav::LoadReturnCode::SUCCESS)
+{
+  this->mRawAudio = irData.mRawAudio;
+  this->mRawAudioSampleRate = irData.mRawAudioSampleRate;
+  this->_SetWeights(sampleRate);
+}
+
 double** dsp::ImpulseResponse::Process(double** inputs, const size_t numChannels, const size_t numFrames)
 {
   this->_PrepareBuffers(numChannels, numFrames);
@@ -71,4 +79,11 @@ void dsp::ImpulseResponse::_SetWeights(const double sampleRate)
   for (size_t i = 0, j = irLength - 1; i < irLength; i++, j--)
     this->mWeight[j] = gain * this->mResampled[i];
   this->mHistoryRequired = irLength - 1;
+}
+
+dsp::ImpulseResponse::IRData dsp::ImpulseResponse::GetData() {
+  IRData irData;
+  irData.mRawAudio = this->mRawAudio;
+  irData.mRawAudioSampleRate = this->mRawAudioSampleRate;
+  return irData;
 }

--- a/dsp/ImpulseResponse.h
+++ b/dsp/ImpulseResponse.h
@@ -20,8 +20,11 @@ namespace dsp
 class ImpulseResponse : public History
 {
 public:
+  struct IRData;
   ImpulseResponse(const char* fileName, const double sampleRate);
+  ImpulseResponse(const IRData& irData, const double sampleRate);
   double** Process(double** inputs, const size_t numChannels, const size_t numFrames) override;
+  IRData GetData();
   // TODO states for the IR class
   dsp::wav::LoadReturnCode GetWavState() const { return this->mWavState; };
 
@@ -42,4 +45,11 @@ private:
   // The weights
   Eigen::VectorXf mWeight;
 };
+
+struct dsp::ImpulseResponse::IRData
+{
+  std::vector<float> mRawAudio;
+  double mRawAudioSampleRate;
+};
+
 }; // namespace dsp


### PR DESCRIPTION
Few changes that will enable loading models from serialized sources:

- added IR snapshot - a small struct that will allow to capture current IR configuration, and then recover IR basing on it
- added new method that allows to create DSP basing on directly passed json config instead of file path. 

This is a first part of the solution for issue sdatkinson/NeuralAmpModelerPlugin#163 second part is here: https://github.com/sdatkinson/NeuralAmpModelerPlugin/pull/206
