### PR TITLE
Add wav error message string function to dsp::wav

### DIFF
--- a/dsp/wav.cpp
+++ b/dsp/wav.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <sstream>
 #include <unordered_set>
 #include <vector>
 
@@ -35,6 +36,42 @@ bool ReadChunkAndSkipJunk(std::ifstream& file, char* chunkID)
     file.read(chunkID, 4);
   }
   return file.good();
+}
+
+std::string dsp::wav::GetMsgForLoadReturnCode(LoadReturnCode retCode)
+{
+  std::stringstream message;
+
+  switch (retCode)
+  {
+    case (LoadReturnCode::ERROR_OPENING):
+      message << "Failed to open file (is it being used by another "
+      "program?)";
+      break;
+    case (LoadReturnCode::ERROR_NOT_RIFF): message << "File is not a WAV file."; break;
+    case (LoadReturnCode::ERROR_NOT_WAVE): message << "File is not a WAV file."; break;
+    case (LoadReturnCode::ERROR_MISSING_FMT):
+      message << "File is missing expected format chunk.";
+      break;
+    case (LoadReturnCode::ERROR_INVALID_FILE): message << "WAV file contents are invalid."; break;
+    case (LoadReturnCode::ERROR_UNSUPPORTED_FORMAT_ALAW):
+      message << "Unsupported file format \"A-law\"";
+      break;
+    case (LoadReturnCode::ERROR_UNSUPPORTED_FORMAT_MULAW):
+      message << "Unsupported file format \"mu-law\"";
+      break;
+    case (LoadReturnCode::ERROR_UNSUPPORTED_FORMAT_EXTENSIBLE):
+      message << "Unsupported file format \"extensible\"";
+      break;
+    case (LoadReturnCode::ERROR_NOT_MONO): message << "File is not mono."; break;
+    case (LoadReturnCode::ERROR_UNSUPPORTED_BITS_PER_SAMPLE):
+      message << "Unsupported bits per sample";
+      break;
+    case (dsp::wav::LoadReturnCode::ERROR_OTHER): message << "???"; break;
+    default: message << "???"; break;
+  }
+  
+  return message.str();
 }
 
 dsp::wav::LoadReturnCode dsp::wav::Load(const char* fileName, std::vector<float>& audio, double& sampleRate)

--- a/dsp/wav.h
+++ b/dsp/wav.h
@@ -26,6 +26,10 @@ enum class LoadReturnCode
   ERROR_NOT_MONO,
   ERROR_OTHER
 };
+
+// Get a string describing the error
+std::string GetMsgForLoadReturnCode(LoadReturnCode rc);
+
 // Load a WAV file into a provided array of doubles,
 // And note the sample rate.
 //

--- a/dsp/wav.h
+++ b/dsp/wav.h
@@ -7,6 +7,10 @@
 
 #pragma once
 
+#include <fstream>
+#include <string>
+#include <vector>
+
 namespace dsp
 {
 namespace wav


### PR DESCRIPTION
Whilst working on the plug-in code it seemed moving this here would make sense