### PR TITLE
Add fast tanh and fast sigmoid to LSTM

### DIFF
--- a/NAM/activations.cpp
+++ b/NAM/activations.cpp
@@ -6,6 +6,8 @@ activations::ActivationHardTanh _HARD_TANH = activations::ActivationHardTanh();
 activations::ActivationReLU _RELU = activations::ActivationReLU();
 activations::ActivationSigmoid _SIGMOID = activations::ActivationSigmoid();
 
+bool activations::Activation::using_fast_tanh = false;
+
 std::unordered_map<std::string, activations::Activation*> activations::Activation::_activations =
   {{"Tanh", &_TANH}, {"Hardtanh", &_HARD_TANH}, {"Fasttanh", &_FAST_TANH}, {"ReLU", &_RELU}, {"Sigmoid", &_SIGMOID}};
 
@@ -21,6 +23,8 @@ activations::Activation* activations::Activation::get_activation(const std::stri
 
 void activations::Activation::enable_fast_tanh()
 {
+  activations::Activation::using_fast_tanh = true;
+
   if (_activations["Tanh"] != _activations["Fasttanh"])
   {
     tanh_bak = _activations["Tanh"];
@@ -30,6 +34,8 @@ void activations::Activation::enable_fast_tanh()
 
 void activations::Activation::disable_fast_tanh()
 {
+  activations::Activation::using_fast_tanh = false;
+
   if (_activations["Tanh"] == _activations["Fasttanh"])
   {
     _activations["Tanh"] = tanh_bak;

--- a/NAM/activations.h
+++ b/NAM/activations.h
@@ -32,6 +32,12 @@ inline float fast_tanh(const float x)
           / (2.44506634652299f + (2.44506634652299f + x2) * fabsf(x + 0.814642734961073f * x * ax)));
 }
 
+inline float fast_sigmoid(const float x)
+{
+  return 0.5f * (fast_tanh(x * 0.5f) + 1.0f);
+}
+
+
 class Activation
 {
 public:
@@ -48,6 +54,7 @@ public:
   static Activation* get_activation(const std::string name);
   static void enable_fast_tanh();
   static void disable_fast_tanh();
+  static bool using_fast_tanh;
 
 protected:
   static std::unordered_map<std::string, Activation*> _activations;


### PR DESCRIPTION
This PR adds fast tanh and fast sigmoid activation for LSTM models. It keys off of the enable_fast_tanh()/disable_fast_tanh() methods.

My testing indicates around a 40% performance improvement for LSTM models.