### PR TITLE
Fix some buffers having uninitialized contents after resizing

### DIFF
--- a/NAM/convnet.cpp
+++ b/NAM/convnet.cpp
@@ -110,7 +110,7 @@ convnet::ConvNet::ConvNet(const double loudness, const int channels, const std::
     this->_blocks[i].set_params_(i == 0 ? 1 : channels, channels, dilations[i], batchnorm, activation, it);
   this->_block_vals.resize(this->_blocks.size() + 1);
   for (auto& matrix : this->_block_vals)
-    util::init_matrix(matrix);
+    matrix.setZero();
   std::fill(this->_input_buffer.begin(), this->_input_buffer.end(), 0.0f);
   this->_head = _Head(channels, it);
   if (it != params.end())
@@ -153,7 +153,7 @@ void convnet::ConvNet::_update_buffers_()
   if (this->_block_vals[0].rows() != 1 || this->_block_vals[0].cols() != buffer_size)
   {
     this->_block_vals[0].resize(1, buffer_size);
-    util::init_matrix(this->_block_vals[0]);
+    this->_block_vals[0].setZero();
   }
 
   for (long i = 1; i < this->_block_vals.size(); i++)
@@ -161,7 +161,7 @@ void convnet::ConvNet::_update_buffers_()
     if (this->_block_vals[i].rows() == this->_blocks[i - 1].get_out_channels() && this->_block_vals[i].cols() == buffer_size)
       continue;  // Already has correct size
     this->_block_vals[i].resize(this->_blocks[i - 1].get_out_channels(), buffer_size);
-    util::init_matrix(this->_block_vals[i]);
+    this->_block_vals[i].setZero();
   }
 }
 

--- a/NAM/convnet.cpp
+++ b/NAM/convnet.cpp
@@ -109,6 +109,9 @@ convnet::ConvNet::ConvNet(const double loudness, const int channels, const std::
   for (int i = 0; i < dilations.size(); i++)
     this->_blocks[i].set_params_(i == 0 ? 1 : channels, channels, dilations[i], batchnorm, activation, it);
   this->_block_vals.resize(this->_blocks.size() + 1);
+  for (auto& matrix : this->_block_vals)
+    util::init_matrix(matrix);
+  std::fill(this->_input_buffer.begin(), this->_input_buffer.end(), 0.0f);
   this->_head = _Head(channels, it);
   if (it != params.end())
     throw std::runtime_error("Didn't touch all the params when initializing wavenet");
@@ -146,9 +149,20 @@ void convnet::ConvNet::_update_buffers_()
 {
   this->Buffer::_update_buffers_();
   const long buffer_size = this->_input_buffer.size();
-  this->_block_vals[0].resize(1, buffer_size);
+
+  if (this->_block_vals[0].rows() != 1 || this->_block_vals[0].cols() != buffer_size)
+  {
+    this->_block_vals[0].resize(1, buffer_size);
+    util::init_matrix(this->_block_vals[0]);
+  }
+
   for (long i = 1; i < this->_block_vals.size(); i++)
+  {
+    if (this->_block_vals[i].rows() == this->_blocks[i - 1].get_out_channels() && this->_block_vals[i].cols() == buffer_size)
+      continue;  // Already has correct size
     this->_block_vals[i].resize(this->_blocks[i - 1].get_out_channels(), buffer_size);
+    util::init_matrix(this->_block_vals[i]);
+  }
 }
 
 void convnet::ConvNet::_rewind_buffers_()

--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -114,6 +114,7 @@ void Buffer::_set_receptive_field(const int new_receptive_field, const int input
 {
   this->_receptive_field = new_receptive_field;
   this->_input_buffer.resize(input_buffer_size);
+  std::fill (this->_input_buffer.begin(), this->_input_buffer.end(), 0.0f);
   this->_reset_input_buffer();
 }
 
@@ -130,6 +131,7 @@ void Buffer::_update_buffers_()
       while (new_buffer_size < minimum_input_buffer_size)
         new_buffer_size *= 2;
       this->_input_buffer.resize(new_buffer_size);
+      std::fill (this->_input_buffer.begin(), this->_input_buffer.end(), 0.0f);
     }
   }
 
@@ -142,6 +144,7 @@ void Buffer::_update_buffers_()
     this->_input_buffer[i] = this->_input_post_gain[j];
   // And resize the output buffer:
   this->_output_buffer.resize(num_frames);
+  std::fill (this->_output_buffer.begin(), this->_output_buffer.end(), 0.0f);
 }
 
 void Buffer::_rewind_buffers_()

--- a/NAM/util.cpp
+++ b/NAM/util.cpp
@@ -9,3 +9,10 @@ std::string util::lowercase(const std::string& s)
   std::transform(s.begin(), s.end(), out.begin(), [](unsigned char c) { return std::tolower(c); });
   return out;
 }
+
+void util::init_matrix(Eigen::MatrixXf& matrix)
+{
+  for(auto i = 0; i < matrix.rows(); ++i)
+    for(auto j = 0; j < matrix.cols(); ++j)
+      matrix(i, j) = 0.0f;
+}

--- a/NAM/util.cpp
+++ b/NAM/util.cpp
@@ -9,10 +9,3 @@ std::string util::lowercase(const std::string& s)
   std::transform(s.begin(), s.end(), out.begin(), [](unsigned char c) { return std::tolower(c); });
   return out;
 }
-
-void util::init_matrix(Eigen::MatrixXf& matrix)
-{
-  for(auto i = 0; i < matrix.rows(); ++i)
-    for(auto j = 0; j < matrix.cols(); ++j)
-      matrix(i, j) = 0.0f;
-}

--- a/NAM/util.h
+++ b/NAM/util.h
@@ -3,8 +3,10 @@
 // Utilities
 
 #include <string>
+#include <Eigen/Dense>  // Eigen::MatrixXf
 
 namespace util
 {
 std::string lowercase(const std::string& s);
+void init_matrix(Eigen::MatrixXf& matrix);
 }; // namespace util

--- a/NAM/util.h
+++ b/NAM/util.h
@@ -8,5 +8,4 @@
 namespace util
 {
 std::string lowercase(const std::string& s);
-void init_matrix(Eigen::MatrixXf& matrix);
 }; // namespace util

--- a/NAM/wavenet.cpp
+++ b/NAM/wavenet.cpp
@@ -53,7 +53,7 @@ void wavenet::_Layer::set_num_frames_(const long num_frames)
     return;  // Already has correct size
 
   this->_z.resize(this->_conv.get_out_channels(), num_frames);
-  util::init_matrix(this->_z);
+  this->_z.setZero();
 }
 
 // LayerArray =================================================================
@@ -220,7 +220,7 @@ void wavenet::_Head::set_num_frames_(const long num_frames)
     if (this->_buffers[i].rows() == this->_channels && this->_buffers[i].cols() == num_frames)
       continue;  // Already has correct size
     this->_buffers[i].resize(this->_channels, num_frames);
-    util::init_matrix(this->_buffers[i]);
+    this->_buffers[i].setZero();
   }
 }
 
@@ -380,7 +380,7 @@ void wavenet::WaveNet::_set_num_frames_(const long num_frames)
   for (int i = 0; i < this->_layer_array_outputs.size(); i++)
     this->_layer_array_outputs[i].resize(this->_layer_array_outputs[i].rows(), num_frames);
   this->_head_output.resize(this->_head_output.rows(), num_frames);
-  util::init_matrix(this->_head_output);
+  this->_head_output.setZero();
 
   for (int i = 0; i < this->_layer_arrays.size(); i++)
     this->_layer_arrays[i].set_num_frames_(num_frames);

--- a/NAM/wavenet.cpp
+++ b/NAM/wavenet.cpp
@@ -5,6 +5,7 @@
 #include <Eigen/Dense>
 
 #include "wavenet.h"
+#include "util.h"
 
 wavenet::_DilatedConv::_DilatedConv(const int in_channels, const int out_channels, const int kernel_size,
                                     const int bias, const int dilation)
@@ -48,7 +49,11 @@ void wavenet::_Layer::process_(const Eigen::MatrixXf& input, const Eigen::Matrix
 
 void wavenet::_Layer::set_num_frames_(const long num_frames)
 {
+  if (this->_z.rows() == this->_conv.get_out_channels() && this->_z.cols() == num_frames)
+    return;  // Already has correct size
+
   this->_z.resize(this->_conv.get_out_channels(), num_frames);
+  util::init_matrix(this->_z);
 }
 
 // LayerArray =================================================================
@@ -211,7 +216,12 @@ void wavenet::_Head::process_(Eigen::MatrixXf& inputs, Eigen::MatrixXf& outputs)
 void wavenet::_Head::set_num_frames_(const long num_frames)
 {
   for (int i = 0; i < this->_buffers.size(); i++)
+  {
+    if (this->_buffers[i].rows() == this->_channels && this->_buffers[i].cols() == num_frames)
+      continue;  // Already has correct size
     this->_buffers[i].resize(this->_channels, num_frames);
+    util::init_matrix(this->_buffers[i]);
+  }
 }
 
 void wavenet::_Head::_apply_activation_(Eigen::MatrixXf& x)
@@ -370,6 +380,7 @@ void wavenet::WaveNet::_set_num_frames_(const long num_frames)
   for (int i = 0; i < this->_layer_array_outputs.size(); i++)
     this->_layer_array_outputs[i].resize(this->_layer_array_outputs[i].rows(), num_frames);
   this->_head_output.resize(this->_head_output.rows(), num_frames);
+  util::init_matrix(this->_head_output);
 
   for (int i = 0; i < this->_layer_arrays.size(); i++)
     this->_layer_arrays[i].set_num_frames_(num_frames);


### PR DESCRIPTION
I used _valgrind_ to test my audio plugin, and it spat out a bunch of warnings like this one:

```
==61792== Conditional jump or move depends on uninitialised value(s)
==61792==    at 0x4D4CB77: tanhf (s_tanhf.c:36)
==61792==    by 0x461359: std::tanh(float) (cmath:502)
==61792==    by 0xACCF70: activations::ActivationTanh::apply(float*, long) (activations.h:70)
==61792==    by 0xACCEF9: activations::Activation::apply(Eigen::Block<Eigen::Matrix<float, -1, -1, 0, -1, -1>, -1, -1, true>) (activations.h:50)
==61792==    by 0xAD086B: convnet::ConvNetBlock::process_(Eigen::Matrix<float, -1, -1, 0, -1, -1> const&, Eigen::Matrix<float, -1, -1, 0, -1, -1>&, long, long) const (convnet.cpp:71)
==61792==    by 0xAD10A9: convnet::ConvNet::_process_core_() (convnet.cpp:129)
==61792==    by 0xAD6E69: DSP::process(double**, double**, int, int, double, double, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, double> > > const&) (dsp.cpp:40)
(...)
```
Apparently a lot of times after matrix or vector gets resized, the memory in those buffers isn't initialized before getting referenced. Which could cause garbage data in audio and ML buffers... This patch fixes it.

