### PR TITLE
Implement expected sample rate for DSP class

### DIFF
--- a/NAM/convnet.cpp
+++ b/NAM/convnet.cpp
@@ -94,14 +94,15 @@ void convnet::_Head::process_(const Eigen::MatrixXf& input, Eigen::VectorXf& out
 }
 
 convnet::ConvNet::ConvNet(const int channels, const std::vector<int>& dilations, const bool batchnorm,
-                          const std::string activation, std::vector<float>& params)
-: ConvNet(TARGET_DSP_LOUDNESS, channels, dilations, batchnorm, activation, params)
+                          const std::string activation, std::vector<float>& params, const double expected_sample_rate)
+: ConvNet(TARGET_DSP_LOUDNESS, channels, dilations, batchnorm, activation, params, expected_sample_rate)
 {
 }
 
 convnet::ConvNet::ConvNet(const double loudness, const int channels, const std::vector<int>& dilations,
-                          const bool batchnorm, const std::string activation, std::vector<float>& params)
-: Buffer(loudness, *std::max_element(dilations.begin(), dilations.end()))
+                          const bool batchnorm, const std::string activation, std::vector<float>& params,
+                          const double expected_sample_rate)
+: Buffer(loudness, *std::max_element(dilations.begin(), dilations.end()), expected_sample_rate)
 {
   this->_verify_params(channels, dilations, batchnorm, params.size());
   this->_blocks.resize(dilations.size());

--- a/NAM/convnet.h
+++ b/NAM/convnet.h
@@ -66,9 +66,9 @@ class ConvNet : public Buffer
 {
 public:
   ConvNet(const int channels, const std::vector<int>& dilations, const bool batchnorm, const std::string activation,
-          std::vector<float>& params, const double expected_sample_rate);
+          std::vector<float>& params, const double expected_sample_rate = -1.0);
   ConvNet(const double loudness, const int channels, const std::vector<int>& dilations, const bool batchnorm,
-          const std::string activation, std::vector<float>& params, const double expected_sample_rate);
+          const std::string activation, std::vector<float>& params, const double expected_sample_rate = -1.0);
 
 protected:
   std::vector<ConvNetBlock> _blocks;

--- a/NAM/convnet.h
+++ b/NAM/convnet.h
@@ -66,9 +66,9 @@ class ConvNet : public Buffer
 {
 public:
   ConvNet(const int channels, const std::vector<int>& dilations, const bool batchnorm, const std::string activation,
-          std::vector<float>& params);
+          std::vector<float>& params, const double expected_sample_rate);
   ConvNet(const double loudness, const int channels, const std::vector<int>& dilations, const bool batchnorm,
-          const std::string activation, std::vector<float>& params);
+          const std::string activation, std::vector<float>& params, const double expected_sample_rate);
 
 protected:
   std::vector<ConvNetBlock> _blocks;

--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -16,15 +16,17 @@
 
 constexpr const long _INPUT_BUFFER_SAFETY_FACTOR = 32;
 
-DSP::DSP()
+DSP::DSP(const double expected_sample_rate)
 : mLoudness(TARGET_DSP_LOUDNESS)
+, mExpectedSampleRate(expected_sample_rate)
 , mNormalizeOutputLoudness(false)
 , _stale_params(true)
 {
 }
 
-DSP::DSP(const double loudness)
+DSP::DSP(const double loudness, const double expected_sample_rate)
 : mLoudness(loudness)
+, mExpectedSampleRate(expected_sample_rate)
 , mNormalizeOutputLoudness(false)
 , _stale_params(true)
 {
@@ -94,13 +96,13 @@ void DSP::_apply_output_level_(double** outputs, const int num_channels, const i
 
 // Buffer =====================================================================
 
-Buffer::Buffer(const int receptive_field)
-: Buffer(TARGET_DSP_LOUDNESS, receptive_field)
+Buffer::Buffer(const int receptive_field, const double expected_sample_rate)
+: Buffer(TARGET_DSP_LOUDNESS, receptive_field, expected_sample_rate)
 {
 }
 
-Buffer::Buffer(const double loudness, const int receptive_field)
-: DSP(loudness)
+Buffer::Buffer(const double loudness, const int receptive_field, const double expected_sample_rate)
+: DSP(loudness, expected_sample_rate)
 {
   this->_set_receptive_field(receptive_field);
 }
@@ -171,13 +173,15 @@ void Buffer::finalize_(const int num_frames)
 
 // Linear =====================================================================
 
-Linear::Linear(const int receptive_field, const bool _bias, const std::vector<float>& params)
-: Linear(TARGET_DSP_LOUDNESS, receptive_field, _bias, params)
+Linear::Linear(const int receptive_field, const bool _bias, const std::vector<float>& params,
+               const double expected_sample_rate)
+: Linear(TARGET_DSP_LOUDNESS, receptive_field, _bias, params, expected_sample_rate)
 {
 }
 
-Linear::Linear(const double loudness, const int receptive_field, const bool _bias, const std::vector<float>& params)
-: Buffer(loudness, receptive_field)
+Linear::Linear(const double loudness, const int receptive_field, const bool _bias, const std::vector<float>& params,
+               const double expected_sample_rate)
+: Buffer(loudness, receptive_field, expected_sample_rate)
 {
   if ((int)params.size() != (receptive_field + (_bias ? 1 : 0)))
     throw std::runtime_error(

--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -39,8 +39,8 @@ public:
 class DSP
 {
 public:
-  DSP(const double expected_sample_rate);
-  DSP(const double loudness, const double expected_sample_rate);
+  DSP(const double expected_sample_rate = -1.0);
+  DSP(const double loudness, const double expected_sample_rate = -1.0);
   virtual ~DSP() = default;
   // process() does all of the processing requried to take `inputs` array and
   // fill in the required values on `outputs`.
@@ -110,8 +110,8 @@ protected:
 class Buffer : public DSP
 {
 public:
-  Buffer(const int receptive_field, const double expected_sample_rate);
-  Buffer(const double loudness, const int receptive_field, const double expected_sample_rate);
+  Buffer(const int receptive_field, const double expected_sample_rate = -1.0);
+  Buffer(const double loudness, const int receptive_field, const double expected_sample_rate = -1.0);
   void finalize_(const int num_frames);
 
 protected:
@@ -136,9 +136,9 @@ class Linear : public Buffer
 {
 public:
   Linear(const int receptive_field, const bool _bias, const std::vector<float>& params,
-         const double expected_sample_rate);
+         const double expected_sample_rate = -1.0);
   Linear(const double loudness, const int receptive_field, const bool _bias, const std::vector<float>& params,
-         const double expected_sample_rate);
+         const double expected_sample_rate = -1.0);
   void _process_core_() override;
 
 protected:

--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -210,7 +210,8 @@ private:
 // :param metadata:
 // :param params: The model parameters ("weights")
 // :param expected_sample_rate: Most NAM models implicitly assume that data will be provided to them at some sample
-//     rate. This captures it for other components interfacing with the model to understand its needs.
+//     rate. This captures it for other components interfacing with the model to understand its needs. Use -1.0 for "I
+//     don't know".
 struct dspData
 {
   std::string version;

--- a/NAM/lstm.cpp
+++ b/NAM/lstm.cpp
@@ -64,14 +64,14 @@ void lstm::LSTMCell::process_(const Eigen::VectorXf& x)
 }
 
 lstm::LSTM::LSTM(const int num_layers, const int input_size, const int hidden_size, std::vector<float>& params,
-                 nlohmann::json& parametric)
-: LSTM(TARGET_DSP_LOUDNESS, num_layers, input_size, hidden_size, params, parametric)
+                 nlohmann::json& parametric, const double expected_sample_rate)
+: LSTM(TARGET_DSP_LOUDNESS, num_layers, input_size, hidden_size, params, parametric, expected_sample_rate)
 {
 }
 
 lstm::LSTM::LSTM(const double loudness, const int num_layers, const int input_size, const int hidden_size,
-                 std::vector<float>& params, nlohmann::json& parametric)
-: DSP(loudness)
+                 std::vector<float>& params, nlohmann::json& parametric, const double expected_sample_rate)
+: DSP(loudness, expected_sample_rate)
 {
   this->_init_parametric(parametric);
   std::vector<float>::iterator it = params.begin();

--- a/NAM/lstm.h
+++ b/NAM/lstm.h
@@ -50,9 +50,9 @@ class LSTM : public DSP
 {
 public:
   LSTM(const int num_layers, const int input_size, const int hidden_size, std::vector<float>& params,
-       nlohmann::json& parametric, const double expected_sample_rate);
+       nlohmann::json& parametric, const double expected_sample_rate = -1.0);
   LSTM(const double loudness, const int num_layers, const int input_size, const int hidden_size,
-       std::vector<float>& params, nlohmann::json& parametric, const double expected_sample_rate);
+       std::vector<float>& params, nlohmann::json& parametric, const double expected_sample_rate = -1.0);
   ~LSTM() = default;
 
 protected:

--- a/NAM/lstm.h
+++ b/NAM/lstm.h
@@ -50,9 +50,9 @@ class LSTM : public DSP
 {
 public:
   LSTM(const int num_layers, const int input_size, const int hidden_size, std::vector<float>& params,
-       nlohmann::json& parametric);
+       nlohmann::json& parametric, const double expected_sample_rate);
   LSTM(const double loudness, const int num_layers, const int input_size, const int hidden_size,
-       std::vector<float>& params, nlohmann::json& parametric);
+       std::vector<float>& params, nlohmann::json& parametric, const double expected_sample_rate);
   ~LSTM() = default;
 
 protected:

--- a/NAM/wavenet.cpp
+++ b/NAM/wavenet.cpp
@@ -222,15 +222,16 @@ void wavenet::_Head::_apply_activation_(Eigen::MatrixXf& x)
 // WaveNet ====================================================================
 
 wavenet::WaveNet::WaveNet(const std::vector<wavenet::LayerArrayParams>& layer_array_params, const float head_scale,
-                          const bool with_head, nlohmann::json parametric, std::vector<float> params)
-: WaveNet(TARGET_DSP_LOUDNESS, layer_array_params, head_scale, with_head, parametric, params)
+                          const bool with_head, nlohmann::json parametric, std::vector<float> params,
+                          const double expected_sample_rate)
+: WaveNet(TARGET_DSP_LOUDNESS, layer_array_params, head_scale, with_head, parametric, params, expected_sample_rate)
 {
 }
 
 wavenet::WaveNet::WaveNet(const double loudness, const std::vector<wavenet::LayerArrayParams>& layer_array_params,
                           const float head_scale, const bool with_head, nlohmann::json parametric,
-                          std::vector<float> params)
-: DSP(loudness)
+                          std::vector<float> params, const double expected_sample_rate)
+: DSP(loudness, expected_sample_rate)
 , _num_frames(0)
 , _head_scale(head_scale)
 {

--- a/NAM/wavenet.h
+++ b/NAM/wavenet.h
@@ -168,10 +168,10 @@ class WaveNet : public DSP
 {
 public:
   WaveNet(const std::vector<LayerArrayParams>& layer_array_params, const float head_scale, const bool with_head,
-          nlohmann::json parametric, std::vector<float> params, const double expected_sample_rate);
+          nlohmann::json parametric, std::vector<float> params, const double expected_sample_rate = -1.0);
   WaveNet(const double loudness, const std::vector<LayerArrayParams>& layer_array_params, const float head_scale,
           const bool with_head, nlohmann::json parametric, std::vector<float> params,
-          const double expected_sample_rate);
+          const double expected_sample_rate = -1.0);
 
   //    WaveNet(WaveNet&&) = default;
   //    WaveNet& operator=(WaveNet&&) = default;

--- a/NAM/wavenet.h
+++ b/NAM/wavenet.h
@@ -168,9 +168,10 @@ class WaveNet : public DSP
 {
 public:
   WaveNet(const std::vector<LayerArrayParams>& layer_array_params, const float head_scale, const bool with_head,
-          nlohmann::json parametric, std::vector<float> params);
+          nlohmann::json parametric, std::vector<float> params, const double expected_sample_rate);
   WaveNet(const double loudness, const std::vector<LayerArrayParams>& layer_array_params, const float head_scale,
-          const bool with_head, nlohmann::json parametric, std::vector<float> params);
+          const bool with_head, nlohmann::json parametric, std::vector<float> params,
+          const double expected_sample_rate);
 
   //    WaveNet(WaveNet&&) = default;
   //    WaveNet& operator=(WaveNet&&) = default;


### PR DESCRIPTION
Implements `DSP::GetExpectedSampleRate()` and needed extensions to subclasses.

Resolves #57