### PR TITLE
Fix some wav impulse files would sometimes fail to load ... 

### DIFF
--- a/dsp/wav.cpp
+++ b/dsp/wav.cpp
@@ -182,7 +182,7 @@ dsp::wav::LoadReturnCode dsp::wav::Load(const char* fileName, std::vector<float>
   if (subchunk1Size > 16)
   {
     const int extraBytes = subchunk1Size - 16;
-    const int skipChars = extraBytes / 4;
+    const int skipChars = extraBytes / 4 * 4; // truncate to dword size
     wavFile.ignore(skipChars);
     const int remainder = extraBytes % 4;
     wavFile.read(reinterpret_cast<char*>(&byteRate), remainder);


### PR DESCRIPTION
when the subchunk1Size>16 because the rounded to dword offset calculation was wrong.
Now IR's such as BD_HV_Creamback3_mixed.wav  (in [free pack from Bogren Digital Impulses](https://bogrendigital.com/pages/free-ir-pack)) load perfectly while other common cases (chunk size = 16) still work fine.