### PR TITLE
Allow defining DSP_SAMPLE_FLOAT to have dsp classes use float I/O

### DIFF
--- a/dsp/NoiseGate.cpp
+++ b/dsp/NoiseGate.cpp
@@ -32,7 +32,7 @@ double signum(const double val)
   return (0.0 < val) - (val < 0.0);
 }
 
-double** dsp::noise_gate::Trigger::Process(double** inputs, const size_t numChannels, const size_t numFrames)
+DSP_SAMPLE** dsp::noise_gate::Trigger::Process(DSP_SAMPLE** inputs, const size_t numChannels, const size_t numFrames)
 {
   this->_PrepareBuffers(numChannels, numFrames);
 
@@ -104,7 +104,7 @@ double** dsp::noise_gate::Trigger::Process(double** inputs, const size_t numChan
 
   // Copy input to output
   for (auto c = 0; c < numChannels; c++)
-    memcpy(this->mOutputs[c].data(), inputs[c], numFrames * sizeof(double));
+    memcpy(this->mOutputs[c].data(), inputs[c], numFrames * sizeof(DSP_SAMPLE));
   return this->_GetPointers();
 }
 
@@ -145,7 +145,7 @@ void dsp::noise_gate::Trigger::_PrepareBuffers(const size_t numChannels, const s
 
 // Gain========================================================================
 
-double** dsp::noise_gate::Gain::Process(double** inputs, const size_t numChannels, const size_t numFrames)
+DSP_SAMPLE** dsp::noise_gate::Gain::Process(DSP_SAMPLE** inputs, const size_t numChannels, const size_t numFrames)
 {
   // Assume that SetGainReductionDB() was just called to get data from a
   // trigger. Could use listeners...

--- a/dsp/NoiseGate.h
+++ b/dsp/NoiseGate.h
@@ -35,15 +35,15 @@ const double MINIMUM_LOUDNESS_POWER = pow(10.0, MINIMUM_LOUDNESS_DB / 10.0);
 class Gain : public DSP
 {
 public:
-  double** Process(double** inputs, const size_t numChannels, const size_t numFrames) override;
+  DSP_SAMPLE** Process(DSP_SAMPLE** inputs, const size_t numChannels, const size_t numFrames) override;
 
-  void SetGainReductionDB(std::vector<std::vector<double>>& gainReductionDB)
+  void SetGainReductionDB(std::vector<std::vector<DSP_SAMPLE>>& gainReductionDB)
   {
     this->mGainReductionDB = gainReductionDB;
   }
 
 private:
-  std::vector<std::vector<double>> mGainReductionDB;
+  std::vector<std::vector<DSP_SAMPLE>> mGainReductionDB;
 };
 
 // Part 1 of the noise gate: the trigger.
@@ -89,11 +89,11 @@ class Trigger : public DSP
 public:
   Trigger();
 
-  double** Process(double** inputs, const size_t numChannels, const size_t numFrames) override;
-  std::vector<std::vector<double>> GetGainReduction() const { return this->mGainReductionDB; };
+  DSP_SAMPLE** Process(DSP_SAMPLE** inputs, const size_t numChannels, const size_t numFrames) override;
+  std::vector<std::vector<DSP_SAMPLE>> GetGainReduction() const { return this->mGainReductionDB; };
   void SetParams(const TriggerParams& params) { this->mParams = params; };
   void SetSampleRate(const double sampleRate) { this->mSampleRate = sampleRate; }
-  std::vector<std::vector<double>> GetGainReductionDB() const { return this->mGainReductionDB; };
+  std::vector<std::vector<DSP_SAMPLE>> GetGainReductionDB() const { return this->mGainReductionDB; };
 
   void AddListener(Gain* gain)
   {

--- a/dsp/RecursiveLinearFilter.cpp
+++ b/dsp/RecursiveLinearFilter.cpp
@@ -22,7 +22,8 @@ mOutputStart(outputDegree)
   this->mOutputCoefficients.resize(outputDegree);
 }
 
-double** recursive_linear_filter::Base::Process(double** inputs, const size_t numChannels, const size_t numFrames)
+DSP_SAMPLE** recursive_linear_filter::Base::Process(DSP_SAMPLE** inputs, const size_t numChannels,
+                                                    const size_t numFrames)
 {
   this->_PrepareBuffers(numChannels, numFrames);
   long inputStart = 0;
@@ -40,7 +41,7 @@ double** recursive_linear_filter::Base::Process(double** inputs, const size_t nu
     outputStart = this->mOutputStart;
     for (auto s = 0; s < numFrames; s++)
     {
-      double out = 0.0;
+      DSP_SAMPLE out = 0.0;
       // Compute input terms
       inputStart -= 1;
       if (inputStart < 0)

--- a/dsp/RecursiveLinearFilter.h
+++ b/dsp/RecursiveLinearFilter.h
@@ -22,7 +22,7 @@ class Base : public dsp::DSP
 {
 public:
   Base(const size_t inputDegree, const size_t outputDegree);
-  double** Process(double** inputs, const size_t numChannels, const size_t numFrames) override;
+  DSP_SAMPLE** Process(DSP_SAMPLE** inputs, const size_t numChannels, const size_t numFrames) override;
 
 protected:
   // Methods
@@ -43,8 +43,8 @@ protected:
   // First index is channel
   // Second index, [0] is the current input/output, [1] is the previous, [2] is
   // before that, etc.
-  std::vector<std::vector<double>> mInputHistory;
-  std::vector<std::vector<double>> mOutputHistory;
+  std::vector<std::vector<DSP_SAMPLE>> mInputHistory;
+  std::vector<std::vector<DSP_SAMPLE>> mOutputHistory;
   // Indices for history.
   // Designates which index is currently "0". Use modulus to wrap around.
   long mInputStart;

--- a/dsp/dsp.cpp
+++ b/dsp/dsp.cpp
@@ -27,7 +27,7 @@ void dsp::DSP::_AllocateOutputPointers(const size_t numChannels)
 {
   if (this->mOutputPointers != nullptr)
     throw std::runtime_error("Tried to re-allocate over non-null mOutputPointers");
-  this->mOutputPointers = new double*[numChannels];
+  this->mOutputPointers = new DSP_SAMPLE*[numChannels];
   if (this->mOutputPointers == nullptr)
     throw std::runtime_error("Failed to allocate pointer to output buffer!\n");
   this->mOutputPointersSize = numChannels;
@@ -45,7 +45,7 @@ void dsp::DSP::_DeallocateOutputPointers()
   this->mOutputPointersSize = 0;
 }
 
-double** dsp::DSP::_GetPointers()
+DSP_SAMPLE** dsp::DSP::_GetPointers()
 {
   for (auto c = 0; c < this->_GetNumChannels(); c++)
     this->mOutputPointers[c] = this->mOutputs[c].data();
@@ -110,7 +110,7 @@ void dsp::History::_RewindHistory()
   this->mHistoryIndex = this->mHistoryRequired;
 }
 
-void dsp::History::_UpdateHistory(double** inputs, const size_t numChannels, const size_t numFrames)
+void dsp::History::_UpdateHistory(DSP_SAMPLE** inputs, const size_t numChannels, const size_t numFrames)
 {
   this->_EnsureHistorySize(numFrames);
   if (numChannels < 1)

--- a/dsp/dsp.h
+++ b/dsp/dsp.h
@@ -7,6 +7,12 @@
 #include <unordered_map>
 #include <vector>
 
+#ifdef DSP_SAMPLE_FLOAT
+  #define DSP_SAMPLE float
+#else
+  #define DSP_SAMPLE double
+#endif
+
 // Version 2 DSP abstraction ==================================================
 
 namespace dsp
@@ -26,7 +32,7 @@ public:
   // The output shall be a pointer-to-pointers of matching size.
   // This object instance will own the data referenced by the pointers and be
   // responsible for its allocation and deallocation.
-  virtual double** Process(double** inputs, const size_t numChannels, const size_t numFrames) = 0;
+  virtual DSP_SAMPLE** Process(DSP_SAMPLE** inputs, const size_t numChannels, const size_t numFrames) = 0;
   // Update the parameters of the DSP object according to the provided params.
   // Not declaring a pure virtual bc there's no concrete definition that can
   // use Params.
@@ -46,7 +52,7 @@ protected:
   size_t _GetNumFrames() const { return this->_GetNumChannels() > 0 ? this->mOutputs[0].size() : 0; }
   // Return a pointer-to-pointers for the DSP's output buffers (all channels)
   // Assumes that ._PrepareBuffers()  was called recently enough.
-  double** _GetPointers();
+  DSP_SAMPLE** _GetPointers();
   // Resize mOutputs to (numChannels, numFrames) and ensure that the raw
   // pointers are also keeping up.
   virtual void _PrepareBuffers(const size_t numChannels, const size_t numFrames);
@@ -58,11 +64,11 @@ protected:
   // The output array into which the DSP module's calculations will be written.
   // Pointers to this member's data will be returned by .Process(), and std
   // Will ensure proper allocation.
-  std::vector<std::vector<double>> mOutputs;
+  std::vector<std::vector<DSP_SAMPLE>> mOutputs;
   // A pointer to pointers of which copies will be given out as the output of
   // .Process(). This object will ensure proper allocation and deallocation of
   // the first level; The second level points to .data() from mOutputs.
-  double** mOutputPointers;
+  DSP_SAMPLE** mOutputPointers;
   size_t mOutputPointersSize;
 };
 
@@ -83,7 +89,7 @@ protected:
   void _AdvanceHistoryIndex(const size_t bufferSize);
   // Drop the new samples into the history array.
   // Manages history array size
-  void _UpdateHistory(double** inputs, const size_t numChannels, const size_t numFrames);
+  void _UpdateHistory(DSP_SAMPLE** inputs, const size_t numChannels, const size_t numFrames);
 
   // The history array that's used for DSP calculations.
   std::vector<float> mHistory;


### PR DESCRIPTION
This replaces double I/O for the dsp classes with DSP_SAMPLE. It is set to double by default (so no change for the NAM plugin) but can be switched to float by setting DSP_SAMPLE_FLOAT.

This is similar to the change made to the NAM code. I used a separate define to allow the dsp code to run at a different sample rate if needed/desired.

I just changed the I/O and left parameters as double.