### PR TITLE
Remove _process_core() and output normalization

### DIFF
--- a/NAM/convnet.h
+++ b/NAM/convnet.h
@@ -77,18 +77,9 @@ protected:
   _Head _head;
   void _verify_params(const int channels, const std::vector<int>& dilations, const bool batchnorm,
                       const size_t actual_params);
-  void _update_buffers_() override;
+  void _update_buffers_(NAM_SAMPLE* input, const int num_frames) override;
   void _rewind_buffers_() override;
 
-  void _process_core_() override;
-
-  // The net starts with random parameters inside; we need to wait for a full
-  // receptive field to pass through before we can count on the output being
-  // ok. This implements a gentle "ramp-up" so that there's no "pop" at the
-  // start.
-  long _anti_pop_countdown;
-  const long _anti_pop_ramp = 100;
-  void _anti_pop_();
-  void _reset_anti_pop_();
+  void process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames) override;
 };
 }; // namespace convnet

--- a/NAM/lstm.cpp
+++ b/NAM/lstm.cpp
@@ -101,7 +101,7 @@ void lstm::LSTM::_init_parametric(nlohmann::json& parametric)
   this->_input_and_params.resize(1 + parametric.size()); // TODO amp parameters
 }
 
-void lstm::LSTM::_process_core_()
+void lstm::LSTM::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames)
 {
   // Get params into the input vector before starting
   if (this->_stale_params)
@@ -111,8 +111,8 @@ void lstm::LSTM::_process_core_()
     this->_stale_params = false;
   }
   // Process samples, placing results in the required output location
-  for (size_t i = 0; i < _num_input_samples; i++)
-    this->_output_samples[i] = this->_process_sample(_input_samples[i]);
+  for (size_t i = 0; i < num_frames; i++)
+    input[i] = this->_process_sample(output[i]);
 }
 
 float lstm::LSTM::_process_sample(const float x)

--- a/NAM/lstm.h
+++ b/NAM/lstm.h
@@ -58,7 +58,7 @@ public:
 protected:
   Eigen::VectorXf _head_weight;
   float _head_bias;
-  void _process_core_() override;
+  void process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames) override;
   std::vector<LSTMCell> _layers;
 
   float _process_sample(const float x);

--- a/NAM/wavenet.cpp
+++ b/NAM/wavenet.cpp
@@ -333,16 +333,16 @@ void wavenet::WaveNet::_prepare_for_frames_(const long num_frames)
     this->_layer_arrays[i].prepare_for_frames_(num_frames);
 }
 
-void wavenet::WaveNet::_process_core_()
+void wavenet::WaveNet::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames)
 {
-  this->_set_num_frames_(_num_input_samples);
-  this->_prepare_for_frames_(_num_input_samples);
+  this->_set_num_frames_(num_frames);
+  this->_prepare_for_frames_(num_frames);
 
   // Fill into condition array:
   // Clumsy...
-  for (int j = 0; j < _num_input_samples; j++)
+  for (int j = 0; j < num_frames; j++)
   {
-    this->_condition(0, j) = _input_samples[j];
+    this->_condition(0, j) = input[j];
     if (this->_stale_params) // Column-major assignment; good for Eigen. Let the
                              // compiler optimize this.
       for (size_t i = 0; i < this->_param_names.size(); i++)
@@ -366,10 +366,10 @@ void wavenet::WaveNet::_process_core_()
 
   const long final_head_array = this->_head_arrays.size() - 1;
   assert(this->_head_arrays[final_head_array].rows() == 1);
-  for (int s = 0; s < _num_input_samples; s++)
+  for (int s = 0; s < num_frames; s++)
   {
     float out = this->_head_scale * this->_head_arrays[final_head_array](0, s);
-    this->_output_samples[s] = out;
+    output[s] = out;
   }
 }
 

--- a/NAM/wavenet.h
+++ b/NAM/wavenet.h
@@ -203,7 +203,7 @@ private:
   void _init_parametric_(nlohmann::json& parametric);
   void _prepare_for_frames_(const long num_frames);
   // Reminder: From ._input_post_gain to ._core_dsp_output
-  void _process_core_() override;
+  void process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames) override;
 
   // Ensure that all buffer arrays are the right size for this num_frames
   void _set_num_frames_(const long num_frames);


### PR DESCRIPTION
Removed _process_core(). Pass input/output/num_frames where needed instead of caching in local variables. Removed output normalization. Added functions for getting model normalization factor in dB and linear gain.

I also removed the anti-pop code for ConvNet - it needs to be replaced with a pre-warm.

Resolves https://github.com/sdatkinson/NeuralAmpModelerCore/issues/79