### PR TITLE
[BREAKING] Remove `TARGET_DSP_LOUDNESS`

### DIFF
--- a/NAM/convnet.cpp
+++ b/NAM/convnet.cpp
@@ -115,7 +115,7 @@ convnet::ConvNet::ConvNet(const double loudness, const int channels, const std::
                           const bool batchnorm, const std::string activation, std::vector<float>& params,
                           const double expected_sample_rate)
 : ConvNet(channels, dilations, batchnorm, activation, params, expected_sample_rate)
-  
+
 {
   SetLoudness(loudness);
 }
@@ -159,8 +159,9 @@ void convnet::ConvNet::_update_buffers_(NAM_SAMPLE* input, const int num_frames)
 
   for (size_t i = 1; i < this->_block_vals.size(); i++)
   {
-    if (this->_block_vals[i].rows() == this->_blocks[i - 1].get_out_channels() && this->_block_vals[i].cols() == buffer_size)
-      continue;  // Already has correct size
+    if (this->_block_vals[i].rows() == this->_blocks[i - 1].get_out_channels()
+        && this->_block_vals[i].cols() == buffer_size)
+      continue; // Already has correct size
     this->_block_vals[i].resize(this->_blocks[i - 1].get_out_channels(), buffer_size);
     this->_block_vals[i].setZero();
   }

--- a/NAM/convnet.cpp
+++ b/NAM/convnet.cpp
@@ -95,14 +95,7 @@ void convnet::_Head::process_(const Eigen::MatrixXf& input, Eigen::VectorXf& out
 
 convnet::ConvNet::ConvNet(const int channels, const std::vector<int>& dilations, const bool batchnorm,
                           const std::string activation, std::vector<float>& params, const double expected_sample_rate)
-: ConvNet(TARGET_DSP_LOUDNESS, channels, dilations, batchnorm, activation, params, expected_sample_rate)
-{
-}
-
-convnet::ConvNet::ConvNet(const double loudness, const int channels, const std::vector<int>& dilations,
-                          const bool batchnorm, const std::string activation, std::vector<float>& params,
-                          const double expected_sample_rate)
-: Buffer(loudness, *std::max_element(dilations.begin(), dilations.end()), expected_sample_rate)
+: Buffer(*std::max_element(dilations.begin(), dilations.end()), expected_sample_rate)
 {
   this->_verify_params(channels, dilations, batchnorm, params.size());
   this->_blocks.resize(dilations.size());
@@ -115,7 +108,16 @@ convnet::ConvNet::ConvNet(const double loudness, const int channels, const std::
   std::fill(this->_input_buffer.begin(), this->_input_buffer.end(), 0.0f);
   this->_head = _Head(channels, it);
   if (it != params.end())
-    throw std::runtime_error("Didn't touch all the params when initializing wavenet");
+    throw std::runtime_error("Didn't touch all the params when initializing ConvNet");
+}
+
+convnet::ConvNet::ConvNet(const double loudness, const int channels, const std::vector<int>& dilations,
+                          const bool batchnorm, const std::string activation, std::vector<float>& params,
+                          const double expected_sample_rate)
+: ConvNet(channels, dilations, batchnorm, activation, params, expected_sample_rate)
+  
+{
+  SetLoudness(loudness);
 }
 
 void convnet::ConvNet::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames)

--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -37,14 +37,15 @@ void DSP::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames)
 
 double DSP::GetLoudness() const
 {
-    if (!HasLoudness()) {
+  if (!HasLoudness())
+  {
     throw std::runtime_error("Asked for loudness of a model that doesn't know how loud it is!");
   }
-    return mLoudness;
+  return mLoudness;
 }
 
 void DSP::SetLoudness(const double loudness)
-  {
+{
   mLoudness = loudness;
   mHasLoudness = true;
 }
@@ -89,7 +90,7 @@ void Buffer::_set_receptive_field(const int new_receptive_field, const int input
 {
   this->_receptive_field = new_receptive_field;
   this->_input_buffer.resize(input_buffer_size);
-  std::fill (this->_input_buffer.begin(), this->_input_buffer.end(), 0.0f);
+  std::fill(this->_input_buffer.begin(), this->_input_buffer.end(), 0.0f);
   this->_reset_input_buffer();
 }
 
@@ -98,15 +99,14 @@ void Buffer::_update_buffers_(NAM_SAMPLE* input, const int num_frames)
   // Make sure that the buffer is big enough for the receptive field and the
   // frames needed!
   {
-    const long minimum_input_buffer_size =
-      (long)this->_receptive_field + _INPUT_BUFFER_SAFETY_FACTOR * num_frames;
+    const long minimum_input_buffer_size = (long)this->_receptive_field + _INPUT_BUFFER_SAFETY_FACTOR * num_frames;
     if ((long)this->_input_buffer.size() < minimum_input_buffer_size)
     {
       long new_buffer_size = 2;
       while (new_buffer_size < minimum_input_buffer_size)
         new_buffer_size *= 2;
       this->_input_buffer.resize(new_buffer_size);
-      std::fill (this->_input_buffer.begin(), this->_input_buffer.end(), 0.0f);
+      std::fill(this->_input_buffer.begin(), this->_input_buffer.end(), 0.0f);
     }
   }
 
@@ -119,7 +119,7 @@ void Buffer::_update_buffers_(NAM_SAMPLE* input, const int num_frames)
     this->_input_buffer[i] = input[j];
   // And resize the output buffer:
   this->_output_buffer.resize(num_frames);
-  std::fill (this->_output_buffer.begin(), this->_output_buffer.end(), 0.0f);
+  std::fill(this->_output_buffer.begin(), this->_output_buffer.end(), 0.0f);
 }
 
 void Buffer::_rewind_buffers_()

--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -79,6 +79,7 @@ public:
   // This is included in the API so that downstream solutions can patch in the loudness of models that don't know how
   // loud they are, but so one can also choose not to do so (e.g. if computational costs dictate).
   void SetLoudness(const double loudness);
+
 protected:
   bool mHasLoudness = false;
   // How loud is the model? In dB

--- a/NAM/get_dsp.cpp
+++ b/NAM/get_dsp.cpp
@@ -185,8 +185,8 @@ std::unique_ptr<DSP> get_dsp(dspData& conf)
     const int hidden_size = config["hidden_size"];
     return haveLoudness ? std::make_unique<lstm::LSTM>(
              loudness, num_layers, input_size, hidden_size, params, config["parametric"], expected_sample_rate)
-                        : std::make_unique<lstm::LSTM>(num_layers, input_size, hidden_size, params,
-                                                       config["parametric"], expected_sample_rate);
+                        : std::make_unique<lstm::LSTM>(
+                          num_layers, input_size, hidden_size, params, config["parametric"], expected_sample_rate);
   }
   else if (architecture == "WaveNet" || architecture == "CatWaveNet")
   {
@@ -210,8 +210,8 @@ std::unique_ptr<DSP> get_dsp(dspData& conf)
     auto parametric_json = architecture == "CatWaveNet" ? config["parametric"] : nlohmann::json{};
     return haveLoudness ? std::make_unique<wavenet::WaveNet>(
              loudness, layer_array_params, head_scale, with_head, parametric_json, params, expected_sample_rate)
-                        : std::make_unique<wavenet::WaveNet>(layer_array_params, head_scale, with_head,
-                                                             parametric_json, params, expected_sample_rate);
+                        : std::make_unique<wavenet::WaveNet>(
+                          layer_array_params, head_scale, with_head, parametric_json, params, expected_sample_rate);
   }
   else
   {

--- a/NAM/lstm.cpp
+++ b/NAM/lstm.cpp
@@ -65,13 +65,7 @@ void lstm::LSTMCell::process_(const Eigen::VectorXf& x)
 
 lstm::LSTM::LSTM(const int num_layers, const int input_size, const int hidden_size, std::vector<float>& params,
                  nlohmann::json& parametric, const double expected_sample_rate)
-: LSTM(TARGET_DSP_LOUDNESS, num_layers, input_size, hidden_size, params, parametric, expected_sample_rate)
-{
-}
-
-lstm::LSTM::LSTM(const double loudness, const int num_layers, const int input_size, const int hidden_size,
-                 std::vector<float>& params, nlohmann::json& parametric, const double expected_sample_rate)
-: DSP(loudness, expected_sample_rate)
+: DSP(expected_sample_rate)
 {
   this->_init_parametric(parametric);
   std::vector<float>::iterator it = params.begin();
@@ -82,6 +76,14 @@ lstm::LSTM::LSTM(const double loudness, const int num_layers, const int input_si
     this->_head_weight[i] = *(it++);
   this->_head_bias = *(it++);
   assert(it == params.end());
+}
+
+lstm::LSTM::LSTM(const double loudness, const int num_layers, const int input_size, const int hidden_size,
+                 std::vector<float>& params, nlohmann::json& parametric, const double expected_sample_rate)
+: LSTM(num_layers, input_size, hidden_size, params, parametric, expected_sample_rate)
+  
+{
+  SetLoudness(loudness);
 }
 
 void lstm::LSTM::_init_parametric(nlohmann::json& parametric)

--- a/NAM/lstm.cpp
+++ b/NAM/lstm.cpp
@@ -81,7 +81,7 @@ lstm::LSTM::LSTM(const int num_layers, const int input_size, const int hidden_si
 lstm::LSTM::LSTM(const double loudness, const int num_layers, const int input_size, const int hidden_size,
                  std::vector<float>& params, nlohmann::json& parametric, const double expected_sample_rate)
 : LSTM(num_layers, input_size, hidden_size, params, parametric, expected_sample_rate)
-  
+
 {
   SetLoudness(loudness);
 }

--- a/NAM/util.h
+++ b/NAM/util.h
@@ -3,7 +3,7 @@
 // Utilities
 
 #include <string>
-#include <Eigen/Dense>  // Eigen::MatrixXf
+#include <Eigen/Dense> // Eigen::MatrixXf
 
 namespace util
 {

--- a/NAM/wavenet.cpp
+++ b/NAM/wavenet.cpp
@@ -50,7 +50,7 @@ void wavenet::_Layer::process_(const Eigen::MatrixXf& input, const Eigen::Matrix
 void wavenet::_Layer::set_num_frames_(const long num_frames)
 {
   if (this->_z.rows() == this->_conv.get_out_channels() && this->_z.cols() == num_frames)
-    return;  // Already has correct size
+    return; // Already has correct size
 
   this->_z.resize(this->_conv.get_out_channels(), num_frames);
   this->_z.setZero();
@@ -218,7 +218,7 @@ void wavenet::_Head::set_num_frames_(const long num_frames)
   for (size_t i = 0; i < this->_buffers.size(); i++)
   {
     if (this->_buffers[i].rows() == this->_channels && this->_buffers[i].cols() == num_frames)
-      continue;  // Already has correct size
+      continue; // Already has correct size
     this->_buffers[i].resize(this->_channels, num_frames);
     this->_buffers[i].setZero();
   }

--- a/NAM/wavenet.cpp
+++ b/NAM/wavenet.cpp
@@ -234,14 +234,7 @@ void wavenet::_Head::_apply_activation_(Eigen::MatrixXf& x)
 wavenet::WaveNet::WaveNet(const std::vector<wavenet::LayerArrayParams>& layer_array_params, const float head_scale,
                           const bool with_head, nlohmann::json parametric, std::vector<float> params,
                           const double expected_sample_rate)
-: WaveNet(TARGET_DSP_LOUDNESS, layer_array_params, head_scale, with_head, parametric, params, expected_sample_rate)
-{
-}
-
-wavenet::WaveNet::WaveNet(const double loudness, const std::vector<wavenet::LayerArrayParams>& layer_array_params,
-                          const float head_scale, const bool with_head, nlohmann::json parametric,
-                          std::vector<float> params, const double expected_sample_rate)
-: DSP(loudness, expected_sample_rate)
+: DSP(expected_sample_rate)
 , _num_frames(0)
 , _head_scale(head_scale)
 {
@@ -284,6 +277,14 @@ wavenet::WaveNet::WaveNet(const double loudness, const std::vector<wavenet::Laye
     this->finalize_(1);
     sample = 0;
   }
+}
+
+wavenet::WaveNet::WaveNet(const double loudness, const std::vector<wavenet::LayerArrayParams>& layer_array_params,
+                          const float head_scale, const bool with_head, nlohmann::json parametric,
+                          std::vector<float> params, const double expected_sample_rate)
+: WaveNet(layer_array_params, head_scale, with_head, parametric, params, expected_sample_rate)
+{
+  SetLoudness(loudness);
 }
 
 void wavenet::WaveNet::finalize_(const int num_frames)


### PR DESCRIPTION
Resolves #82 

Remove `TARGET_DSP_LOUDNESS`
Implement functions for loudness API:
* `HasLoudness()`
* `GetLoudness()`
* `SetLoudness()`