### PR TITLE
[BREAKING] Remove constructors with loudness

### DIFF
--- a/NAM/convnet.cpp
+++ b/NAM/convnet.cpp
@@ -111,15 +111,6 @@ convnet::ConvNet::ConvNet(const int channels, const std::vector<int>& dilations,
     throw std::runtime_error("Didn't touch all the params when initializing ConvNet");
 }
 
-convnet::ConvNet::ConvNet(const double loudness, const int channels, const std::vector<int>& dilations,
-                          const bool batchnorm, const std::string activation, std::vector<float>& params,
-                          const double expected_sample_rate)
-: ConvNet(channels, dilations, batchnorm, activation, params, expected_sample_rate)
-
-{
-  SetLoudness(loudness);
-}
-
 void convnet::ConvNet::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames)
 
 {

--- a/NAM/convnet.h
+++ b/NAM/convnet.h
@@ -37,7 +37,7 @@ private:
 class ConvNetBlock
 {
 public:
-  ConvNetBlock() {};
+  ConvNetBlock(){};
   void set_params_(const int in_channels, const int out_channels, const int _dilation, const bool batchnorm,
                    const std::string activation, std::vector<float>::iterator& params);
   void process_(const Eigen::MatrixXf& input, Eigen::MatrixXf& output, const long i_start, const long i_end) const;
@@ -46,20 +46,20 @@ public:
 
 private:
   BatchNorm batchnorm;
-  bool _batchnorm=false;
-  activations::Activation* activation=nullptr;
+  bool _batchnorm = false;
+  activations::Activation* activation = nullptr;
 };
 
 class _Head
 {
 public:
-  _Head() {};
+  _Head(){};
   _Head(const int channels, std::vector<float>::iterator& params);
   void process_(const Eigen::MatrixXf& input, Eigen::VectorXf& output, const long i_start, const long i_end) const;
 
 private:
   Eigen::VectorXf _weight;
-  float _bias=0.0f;
+  float _bias = 0.0f;
 };
 
 class ConvNet : public Buffer

--- a/NAM/convnet.h
+++ b/NAM/convnet.h
@@ -37,7 +37,7 @@ private:
 class ConvNetBlock
 {
 public:
-  ConvNetBlock() { this->_batchnorm = false; };
+  ConvNetBlock() {};
   void set_params_(const int in_channels, const int out_channels, const int _dilation, const bool batchnorm,
                    const std::string activation, std::vector<float>::iterator& params);
   void process_(const Eigen::MatrixXf& input, Eigen::MatrixXf& output, const long i_start, const long i_end) const;
@@ -46,20 +46,20 @@ public:
 
 private:
   BatchNorm batchnorm;
-  bool _batchnorm;
-  activations::Activation* activation;
+  bool _batchnorm=false;
+  activations::Activation* activation=nullptr;
 };
 
 class _Head
 {
 public:
-  _Head() { this->_bias = (float)0.0; };
+  _Head() {};
   _Head(const int channels, std::vector<float>::iterator& params);
   void process_(const Eigen::MatrixXf& input, Eigen::VectorXf& output, const long i_start, const long i_end) const;
 
 private:
   Eigen::VectorXf _weight;
-  float _bias;
+  float _bias=0.0f;
 };
 
 class ConvNet : public Buffer
@@ -67,8 +67,7 @@ class ConvNet : public Buffer
 public:
   ConvNet(const int channels, const std::vector<int>& dilations, const bool batchnorm, const std::string activation,
           std::vector<float>& params, const double expected_sample_rate = -1.0);
-  ConvNet(const double loudness, const int channels, const std::vector<int>& dilations, const bool batchnorm,
-          const std::string activation, std::vector<float>& params, const double expected_sample_rate = -1.0);
+  ~ConvNet() = default;
 
 protected:
   std::vector<ConvNetBlock> _blocks;

--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -21,13 +21,6 @@ DSP::DSP(const double expected_sample_rate)
 {
 }
 
-DSP::DSP(const double loudness, const double expected_sample_rate)
-: mLoudness(loudness)
-, mExpectedSampleRate(expected_sample_rate)
-, _stale_params(true)
-{
-}
-
 void DSP::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames)
 {
   // Default implementation is the null operation
@@ -73,12 +66,6 @@ Buffer::Buffer(const int receptive_field, const double expected_sample_rate)
 : DSP(expected_sample_rate)
 {
   this->_set_receptive_field(receptive_field);
-}
-
-Buffer::Buffer(const double loudness, const int receptive_field, const double expected_sample_rate)
-: Buffer(receptive_field, expected_sample_rate)
-{
-  SetLoudness(loudness);
 }
 
 void Buffer::_set_receptive_field(const int new_receptive_field)
@@ -163,13 +150,6 @@ Linear::Linear(const int receptive_field, const bool _bias, const std::vector<fl
   for (int i = 0; i < this->_receptive_field; i++)
     this->_weight(i) = params[receptive_field - 1 - i];
   this->_bias = _bias ? params[receptive_field] : (float)0.0;
-}
-
-Linear::Linear(const double loudness, const int receptive_field, const bool _bias, const std::vector<float>& params,
-               const double expected_sample_rate)
-: Linear(receptive_field, _bias, params, expected_sample_rate)
-{
-  SetLoudness(loudness);
 }
 
 void Linear::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames)

--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -45,13 +45,10 @@ public:
 class DSP
 {
 public:
-  // Two constructors are provided: one where we know how loud the model is, and one where we don't.
   // Older models won't know, but newer ones will come with a loudness from the training based on their response to a
   // standardized input.
   // We may choose to have the models figure out for themselves how loud they are in here in the future.
   DSP(const double expected_sample_rate);
-  // Initialization where we know how loud the model is.
-  DSP(const double loudness, const double expected_sample_rate);
   virtual ~DSP() = default;
   // process() does all of the processing requried to take `input` array and
   // fill in the required values on `output`.
@@ -75,9 +72,9 @@ public:
   double GetLoudness() const;
   // Get whether the model knows how loud it is.
   bool HasLoudness() const { return mHasLoudness; };
-  // Option to set the loudness.
-  // This is included in the API so that downstream solutions can patch in the loudness of models that don't know how
-  // loud they are, but so one can also choose not to do so (e.g. if computational costs dictate).
+  // Set the loudness, in dB.
+  // This is usually defined to be the loudness to a standardized input. The trainer has its own, but you can always
+  // use this to define it a different way if you like yours better.
   void SetLoudness(const double loudness);
 
 protected:
@@ -106,7 +103,6 @@ class Buffer : public DSP
 {
 public:
   Buffer(const int receptive_field, const double expected_sample_rate = -1.0);
-  Buffer(const double loudness, const int receptive_field, const double expected_sample_rate = -1.0);
   void finalize_(const int num_frames);
 
 protected:
@@ -131,8 +127,6 @@ class Linear : public Buffer
 {
 public:
   Linear(const int receptive_field, const bool _bias, const std::vector<float>& params,
-         const double expected_sample_rate = -1.0);
-  Linear(const double loudness, const int receptive_field, const bool _bias, const std::vector<float>& params,
          const double expected_sample_rate = -1.0);
   void process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames) override;
 

--- a/NAM/get_dsp.cpp
+++ b/NAM/get_dsp.cpp
@@ -162,8 +162,7 @@ std::unique_ptr<DSP> get_dsp(dspData& conf)
     for (size_t i = 0; i < config["dilations"].size(); i++)
       dilations.push_back(config["dilations"][i]);
     const std::string activation = config["activation"];
-    out = std::make_unique<convnet::ConvNet>(
-                          channels, dilations, batchnorm, activation, params, expectedSampleRate);
+    out = std::make_unique<convnet::ConvNet>(channels, dilations, batchnorm, activation, params, expectedSampleRate);
   }
   else if (architecture == "LSTM")
   {
@@ -171,8 +170,7 @@ std::unique_ptr<DSP> get_dsp(dspData& conf)
     const int input_size = config["input_size"];
     const int hidden_size = config["hidden_size"];
     auto empty_json = nlohmann::json{};
-    out = std::make_unique<lstm::LSTM>(
-                          num_layers, input_size, hidden_size, params, empty_json, expectedSampleRate);
+    out = std::make_unique<lstm::LSTM>(num_layers, input_size, hidden_size, params, empty_json, expectedSampleRate);
   }
   else if (architecture == "CatLSTM")
   {
@@ -180,7 +178,7 @@ std::unique_ptr<DSP> get_dsp(dspData& conf)
     const int input_size = config["input_size"];
     const int hidden_size = config["hidden_size"];
     out = std::make_unique<lstm::LSTM>(
-                          num_layers, input_size, hidden_size, params, config["parametric"], expectedSampleRate);
+      num_layers, input_size, hidden_size, params, config["parametric"], expectedSampleRate);
   }
   else if (architecture == "WaveNet" || architecture == "CatWaveNet")
   {
@@ -203,13 +201,14 @@ std::unique_ptr<DSP> get_dsp(dspData& conf)
     // https://stackoverflow.com/a/73956681/3768284
     auto parametric_json = architecture == "CatWaveNet" ? config["parametric"] : nlohmann::json{};
     out = std::make_unique<wavenet::WaveNet>(
-                          layer_array_params, head_scale, with_head, parametric_json, params, expectedSampleRate);
+      layer_array_params, head_scale, with_head, parametric_json, params, expectedSampleRate);
   }
   else
   {
     throw std::runtime_error("Unrecognized architecture");
   }
-  if (haveLoudness) {
+  if (haveLoudness)
+  {
     out->SetLoudness(loudness);
   }
   return out;

--- a/NAM/lstm.cpp
+++ b/NAM/lstm.cpp
@@ -78,14 +78,6 @@ lstm::LSTM::LSTM(const int num_layers, const int input_size, const int hidden_si
   assert(it == params.end());
 }
 
-lstm::LSTM::LSTM(const double loudness, const int num_layers, const int input_size, const int hidden_size,
-                 std::vector<float>& params, nlohmann::json& parametric, const double expected_sample_rate)
-: LSTM(num_layers, input_size, hidden_size, params, parametric, expected_sample_rate)
-
-{
-  SetLoudness(loudness);
-}
-
 void lstm::LSTM::_init_parametric(nlohmann::json& parametric)
 {
   std::vector<std::string> parametric_names;

--- a/NAM/lstm.h
+++ b/NAM/lstm.h
@@ -51,8 +51,6 @@ class LSTM : public DSP
 public:
   LSTM(const int num_layers, const int input_size, const int hidden_size, std::vector<float>& params,
        nlohmann::json& parametric, const double expected_sample_rate = -1.0);
-  LSTM(const double loudness, const int num_layers, const int input_size, const int hidden_size,
-       std::vector<float>& params, nlohmann::json& parametric, const double expected_sample_rate = -1.0);
   ~LSTM() = default;
 
 protected:

--- a/NAM/wavenet.cpp
+++ b/NAM/wavenet.cpp
@@ -279,14 +279,6 @@ wavenet::WaveNet::WaveNet(const std::vector<wavenet::LayerArrayParams>& layer_ar
   }
 }
 
-wavenet::WaveNet::WaveNet(const double loudness, const std::vector<wavenet::LayerArrayParams>& layer_array_params,
-                          const float head_scale, const bool with_head, nlohmann::json parametric,
-                          std::vector<float> params, const double expected_sample_rate)
-: WaveNet(layer_array_params, head_scale, with_head, parametric, params, expected_sample_rate)
-{
-  SetLoudness(loudness);
-}
-
 void wavenet::WaveNet::finalize_(const int num_frames)
 {
   this->DSP::finalize_(num_frames);

--- a/NAM/wavenet.h
+++ b/NAM/wavenet.h
@@ -169,9 +169,6 @@ class WaveNet : public DSP
 public:
   WaveNet(const std::vector<LayerArrayParams>& layer_array_params, const float head_scale, const bool with_head,
           nlohmann::json parametric, std::vector<float> params, const double expected_sample_rate = -1.0);
-  WaveNet(const double loudness, const std::vector<LayerArrayParams>& layer_array_params, const float head_scale,
-          const bool with_head, nlohmann::json parametric, std::vector<float> params,
-          const double expected_sample_rate = -1.0);
 
   //    WaveNet(WaveNet&&) = default;
   //    WaveNet& operator=(WaveNet&&) = default;


### PR DESCRIPTION
Use `SetLoudness()` after construction instead.

Resolves #86

A few other cleanups in there too 🙂 