### PR TITLE
[BREAKING] Remove parametric modeling code

### DIFF
--- a/NAM/convnet.h
+++ b/NAM/convnet.h
@@ -23,7 +23,7 @@ class BatchNorm
 {
 public:
   BatchNorm(){};
-  BatchNorm(const int dim, std::vector<float>::iterator& params);
+  BatchNorm(const int dim, std::vector<float>::iterator& weights);
   void process_(Eigen::MatrixXf& input, const long i_start, const long i_end) const;
 
 private:
@@ -40,8 +40,8 @@ class ConvNetBlock
 {
 public:
   ConvNetBlock(){};
-  void set_params_(const int in_channels, const int out_channels, const int _dilation, const bool batchnorm,
-                   const std::string activation, std::vector<float>::iterator& params);
+  void set_weights_(const int in_channels, const int out_channels, const int _dilation, const bool batchnorm,
+                    const std::string activation, std::vector<float>::iterator& weights);
   void process_(const Eigen::MatrixXf& input, Eigen::MatrixXf& output, const long i_start, const long i_end) const;
   long get_out_channels() const;
   Conv1D conv;
@@ -56,7 +56,7 @@ class _Head
 {
 public:
   _Head(){};
-  _Head(const int channels, std::vector<float>::iterator& params);
+  _Head(const int channels, std::vector<float>::iterator& weights);
   void process_(const Eigen::MatrixXf& input, Eigen::VectorXf& output, const long i_start, const long i_end) const;
 
 private:
@@ -68,7 +68,7 @@ class ConvNet : public Buffer
 {
 public:
   ConvNet(const int channels, const std::vector<int>& dilations, const bool batchnorm, const std::string activation,
-          std::vector<float>& params, const double expected_sample_rate = -1.0);
+          std::vector<float>& weights, const double expected_sample_rate = -1.0);
   ~ConvNet() = default;
 
 protected:
@@ -76,8 +76,8 @@ protected:
   std::vector<Eigen::MatrixXf> _block_vals;
   Eigen::VectorXf _head_output;
   _Head _head;
-  void _verify_params(const int channels, const std::vector<int>& dilations, const bool batchnorm,
-                      const size_t actual_params);
+  void _verify_weights(const int channels, const std::vector<int>& dilations, const bool batchnorm,
+                       const size_t actual_weights);
   void _update_buffers_(NAM_SAMPLE* input, const int num_frames) override;
   void _rewind_buffers_() override;
 

--- a/NAM/lstm.cpp
+++ b/NAM/lstm.cpp
@@ -4,7 +4,7 @@
 
 #include "lstm.h"
 
-nam::lstm::LSTMCell::LSTMCell(const int input_size, const int hidden_size, std::vector<float>::iterator& params)
+nam::lstm::LSTMCell::LSTMCell(const int input_size, const int hidden_size, std::vector<float>::iterator& weights)
 {
   // Resize arrays
   this->_w.resize(4 * hidden_size, input_size + hidden_size);
@@ -16,14 +16,14 @@ nam::lstm::LSTMCell::LSTMCell(const int input_size, const int hidden_size, std::
   // Assign in row-major because that's how PyTorch goes.
   for (int i = 0; i < this->_w.rows(); i++)
     for (int j = 0; j < this->_w.cols(); j++)
-      this->_w(i, j) = *(params++);
+      this->_w(i, j) = *(weights++);
   for (int i = 0; i < this->_b.size(); i++)
-    this->_b[i] = *(params++);
+    this->_b[i] = *(weights++);
   const int h_offset = input_size;
   for (int i = 0; i < hidden_size; i++)
-    this->_xh[i + h_offset] = *(params++);
+    this->_xh[i + h_offset] = *(weights++);
   for (int i = 0; i < hidden_size; i++)
-    this->_c[i] = *(params++);
+    this->_c[i] = *(weights++);
 }
 
 void nam::lstm::LSTMCell::process_(const Eigen::VectorXf& x)
@@ -63,48 +63,23 @@ void nam::lstm::LSTMCell::process_(const Eigen::VectorXf& x)
   }
 }
 
-nam::lstm::LSTM::LSTM(const int num_layers, const int input_size, const int hidden_size, std::vector<float>& params,
-                      nlohmann::json& parametric, const double expected_sample_rate)
+nam::lstm::LSTM::LSTM(const int num_layers, const int input_size, const int hidden_size, std::vector<float>& weights,
+                      const double expected_sample_rate)
 : DSP(expected_sample_rate)
 {
-  this->_init_parametric(parametric);
-  std::vector<float>::iterator it = params.begin();
+  this->_input.resize(1);
+  std::vector<float>::iterator it = weights.begin();
   for (int i = 0; i < num_layers; i++)
     this->_layers.push_back(LSTMCell(i == 0 ? input_size : hidden_size, hidden_size, it));
   this->_head_weight.resize(hidden_size);
   for (int i = 0; i < hidden_size; i++)
     this->_head_weight[i] = *(it++);
   this->_head_bias = *(it++);
-  assert(it == params.end());
-}
-
-void nam::lstm::LSTM::_init_parametric(nlohmann::json& parametric)
-{
-  std::vector<std::string> parametric_names;
-  for (nlohmann::json::iterator it = parametric.begin(); it != parametric.end(); ++it)
-  {
-    parametric_names.push_back(it.key());
-  }
-  std::sort(parametric_names.begin(), parametric_names.end());
-  {
-    int i = 1;
-    for (std::vector<std::string>::iterator it = parametric_names.begin(); it != parametric_names.end(); ++it, i++)
-      this->_parametric_map[*it] = i;
-  }
-
-  this->_input_and_params.resize(1 + parametric.size()); // TODO amp parameters
+  assert(it == weights.end());
 }
 
 void nam::lstm::LSTM::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames)
 {
-  // Get params into the input vector before starting
-  if (this->_stale_params)
-  {
-    for (std::unordered_map<std::string, double>::iterator it = this->_params.begin(); it != this->_params.end(); ++it)
-      this->_input_and_params[this->_parametric_map[it->first]] = it->second;
-    this->_stale_params = false;
-  }
-  // Process samples, placing results in the required output location
   for (size_t i = 0; i < num_frames; i++)
     output[i] = this->_process_sample(input[i]);
 }
@@ -113,8 +88,8 @@ float nam::lstm::LSTM::_process_sample(const float x)
 {
   if (this->_layers.size() == 0)
     return x;
-  this->_input_and_params(0) = x;
-  this->_layers[0].process_(this->_input_and_params);
+  this->_input(0) = x;
+  this->_layers[0].process_(this->_input);
   for (size_t i = 1; i < this->_layers.size(); i++)
     this->_layers[i].process_(this->_layers[i - 1].get_hidden_state());
   return this->_head_weight.dot(this->_layers[this->_layers.size() - 1].get_hidden_state()) + this->_head_bias;

--- a/NAM/lstm.h
+++ b/NAM/lstm.h
@@ -7,7 +7,6 @@
 #include <Eigen/Dense>
 
 #include "dsp.h"
-#include "json.hpp"
 
 namespace nam
 {
@@ -23,7 +22,7 @@ namespace lstm
 class LSTMCell
 {
 public:
-  LSTMCell(const int input_size, const int hidden_size, std::vector<float>::iterator& params);
+  LSTMCell(const int input_size, const int hidden_size, std::vector<float>::iterator& weights);
   Eigen::VectorXf get_hidden_state() const { return this->_xh(Eigen::placeholders::lastN(this->_get_hidden_size())); };
   void process_(const Eigen::VectorXf& x);
 
@@ -51,8 +50,8 @@ private:
 class LSTM : public DSP
 {
 public:
-  LSTM(const int num_layers, const int input_size, const int hidden_size, std::vector<float>& params,
-       nlohmann::json& parametric, const double expected_sample_rate = -1.0);
+  LSTM(const int num_layers, const int input_size, const int hidden_size, std::vector<float>& weights,
+       const double expected_sample_rate = -1.0);
   ~LSTM() = default;
 
 protected:
@@ -63,13 +62,9 @@ protected:
 
   float _process_sample(const float x);
 
-  // Initialize the parametric map
-  void _init_parametric(nlohmann::json& parametric);
-
-  // Mapping from param name to index in _input_and_params:
-  std::map<std::string, int> _parametric_map;
-  // Input sample first, params second
-  Eigen::VectorXf _input_and_params;
+  // Input to the LSTM.
+  // Since this is assumed to not be a parametric model, its shape should be (1,)
+  Eigen::VectorXf _input;
 };
 }; // namespace lstm
 }; // namespace nam

--- a/NAM/wavenet.h
+++ b/NAM/wavenet.h
@@ -195,7 +195,7 @@ private:
 
   virtual int _get_condition_dim() const { return 1; };
   // Fill in the "condition" array that's fed into the various parts of the net.
-  void _set_condition_array(NAM_SAMPLE* input, const int num_frames);
+  virtual void _set_condition_array(NAM_SAMPLE* input, const int num_frames);
   // Ensure that all buffer arrays are the right size for this num_frames
   void _set_num_frames_(const long num_frames);
 };

--- a/NAM/wavenet.h
+++ b/NAM/wavenet.h
@@ -30,7 +30,7 @@ public:
   , _1x1(channels, channels, true)
   , _activation(activations::Activation::get_activation(activation))
   , _gated(gated){};
-  void set_params_(std::vector<float>::iterator& params);
+  void set_weights_(std::vector<float>::iterator& weights);
   // :param `input`: from previous layer
   // :param `output`: to next layer
   void process_(const Eigen::MatrixXf& input, const Eigen::MatrixXf& condition, Eigen::MatrixXf& head_input,
@@ -108,7 +108,7 @@ public:
                 Eigen::MatrixXf& head_outputs // post head-rechannel
   );
   void set_num_frames_(const long num_frames);
-  void set_params_(std::vector<float>::iterator& it);
+  void set_weights_(std::vector<float>::iterator& it);
 
   // "Zero-indexed" receptive field.
   // E.g. a 1x1 convolution has a z.i.r.f. of zero.
@@ -144,7 +144,7 @@ class _Head
 {
 public:
   _Head(const int input_size, const int num_layers, const int channels, const std::string activation);
-  void set_params_(std::vector<float>::iterator& params);
+  void set_weights_(std::vector<float>::iterator& weights);
   // NOTE: the head transforms the provided input by applying a nonlinearity
   // to it in-place!
   void process_(Eigen::MatrixXf& inputs, Eigen::MatrixXf& outputs);
@@ -165,19 +165,15 @@ private:
 };
 
 // The main WaveNet model
-// Both parametric and not; difference is handled at param read-in.
 class WaveNet : public DSP
 {
 public:
   WaveNet(const std::vector<LayerArrayParams>& layer_array_params, const float head_scale, const bool with_head,
-          nlohmann::json parametric, std::vector<float> params, const double expected_sample_rate = -1.0);
-
-  //    WaveNet(WaveNet&&) = default;
-  //    WaveNet& operator=(WaveNet&&) = default;
+          std::vector<float> weights, const double expected_sample_rate = -1.0);
   ~WaveNet() = default;
 
   void finalize_(const int num_frames) override;
-  void set_params_(std::vector<float>& params);
+  void set_weights_(std::vector<float>& weights);
 
 private:
   long _num_frames;
@@ -193,16 +189,13 @@ private:
   float _head_scale;
   Eigen::MatrixXf _head_output;
 
-  // Names of the params, sorted.
-  // TODO move this up, ugh.
-  std::vector<std::string> _param_names;
-
   void _advance_buffers_(const int num_frames);
-  // Get the info from the parametric config
-  void _init_parametric_(nlohmann::json& parametric);
   void _prepare_for_frames_(const long num_frames);
   void process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames) override;
 
+  virtual int _get_condition_dim() const { return 1; };
+  // Fill in the "condition" array that's fed into the various parts of the net.
+  void _set_condition_array(NAM_SAMPLE* input, const int num_frames);
   // Ensure that all buffer arrays are the right size for this num_frames
   void _set_num_frames_(const long num_frames);
 };


### PR DESCRIPTION
Resolves #81.

Also renaming "params" variables to "weights" where it's referring to _model weights_ (aka parameters, but since I've used "parametric" in NAM to refer to modeling that's parameterized wrt "real world" parameters, I want it to not be confusing).

Note: I've attempted to leave in hooks in locations where extending this library's classes to recover the parametric functionality can be done by downstream projects who are interested in it without having to tear up too much code. Hence the virtual methods in the WaveNet, e.g.