### PR TITLE
Performance optimization, avoiding memory allocations on the realtime audio thread.

### DIFF
--- a/NAM/activations.h
+++ b/NAM/activations.h
@@ -27,11 +27,11 @@ inline float hard_tanh(float x)
 
 inline float fast_tanh(const float x)
 {
-  const float ax = fabsf(x);
+  const float ax = std::abs(x);
   const float x2 = x * x;
 
   return (x * (2.45550750702956f + 2.45550750702956f * ax + (0.893229853513558f + 0.821226666969744f * ax) * x2)
-          / (2.44506634652299f + (2.44506634652299f + x2) * fabsf(x + 0.814642734961073f * x * ax)));
+          / (2.44506634652299f + (2.44506634652299f + x2) * std::abs(x + 0.814642734961073f * x * ax)));
 }
 
 inline float fast_sigmoid(const float x)

--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -246,6 +246,19 @@ void nam::Conv1x1::set_weights_(std::vector<float>::iterator& weights)
       this->_bias(i) = *(weights++);
 }
 
+
+void nam::Conv1x1::process(const Eigen::MatrixXf& input, Eigen::MatrixXf &output) 
+{
+  if (this->_do_bias)
+  {
+    // (this->_weight * input).colwise() + this->_bias (with no temporary allocations)
+    _tmpMul.noalias() = (this->_weight * input);  
+
+    output.noalias() =  _tmpMul.colwise() + this->_bias;
+  }
+  else
+    output.noalias() = this->_weight * input;
+}
 Eigen::MatrixXf nam::Conv1x1::process(const Eigen::MatrixXf& input) const
 {
   if (this->_do_bias)

--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -141,6 +141,7 @@ public:
   int get_dilation() const { return this->_dilation; };
 
 private:
+  Eigen::MatrixXf _tmpMul;
   // Gonna wing this...
   // conv[kernel](cout, cin)
   std::vector<Eigen::MatrixXf> _weight;
@@ -156,11 +157,15 @@ public:
   void set_weights_(std::vector<float>::iterator& weights);
   // :param input: (N,Cin) or (Cin,)
   // :return: (N,Cout) or (Cout,), respectively
-  Eigen::MatrixXf process(const Eigen::MatrixXf& input) const;
+
+  void process(const Eigen::MatrixXf& input, Eigen::MatrixXf &output);
 
   long get_out_channels() const { return this->_weight.rows(); };
 
 private:
+  Eigen::MatrixXf process(const Eigen::MatrixXf& input) const;// yyy remove me
+
+  Eigen::MatrixXf _tmpMul;
   Eigen::MatrixXf _weight;
   Eigen::VectorXf _bias;
   bool _do_bias;

--- a/NAM/wavenet.h
+++ b/NAM/wavenet.h
@@ -41,6 +41,10 @@ public:
   long get_kernel_size() const { return this->_conv.get_kernel_size(); };
 
 private:
+  Eigen::MatrixXf _tmpMixin;
+  Eigen::MatrixXf _tmpConv1x1;
+  Eigen::MatrixXf _tmpTopRows;
+
   // The dilated convolution at the front of the block
   _DilatedConv _conv;
   // Input mixin
@@ -114,6 +118,9 @@ public:
   long get_receptive_field() const;
 
 private:
+  Eigen::MatrixXf _tmpConv1x1Process;
+  Eigen::MatrixXf _tmpHeadProcess;
+
   long _buffer_start;
   // The rechannel before the layers
   Conv1x1 _rechannel;


### PR DESCRIPTION
The first commit is pretty trivial. Using std:abs instead of fabs allows compilers (GCC specificall) to apply simd vectorization optimizations of the of of the activation ::apply functions for  ActivationFastTanh::apply,  which provides a potential 75% performance gain. Curiously, profiling didn't indicate any performance gain on aarch64, even the the code was vectorized. But it's not worse, on aarch64,  and it might well yield a ~7% speed improvement on x64 architectures. I include it because it's not wrong, it's incredibly harmless, and might be beneficial on x64.

Profile results:  65 profile hits, 10.0% of overall CPU use in activations::ActivationFastTanh::apply

The second commit is more complicated. Eigen matrix math  generates temporary matrices when doing matrix math, under various circumstances. This is not good, because temporary matrices do heap allocations and deallocations, which has significant consequences when running on a realtime audio thread.  See the following link for details:

   https://eigen.tuxfamily.org/index.php?title=FAQ#Where_in_my_program_are_temporary_objects_created.3F:~:text=The%20Eigen%20library%20sometimes%20creates%20temporary%20matrices%20to%20hold%20intermediate%20results

The second  commit revises your code to use member-variable matrixes (which allocate once), in order to avoid generating automatic temporaries. After the first cycle, NeuralAmpModelerCore code now does no memory allocations on the realtime thread.

According to profiling and benchmark results, this commit improves performance by 19% on aarch64, but more importantly seems to reduce the amount of jitter in per-frame CPU time. Before the patch, CPU use was running at between 50% and 75% with frequent audio underruns; with the patch, CPU-use is rock steady at about 43%.

fwiw, that 19% performance boost (and the probable jitter reduction) is precious to me, as it allows NAM to run passably well on a Pi 4. Before the optimization, my NAM port was causing audio underruns at a furious rate; with the optimizations, it runs stably with no overruns.

Profile results running on a Rasberry Pi 4:

Before:   758 Profiler hits, 96.9% of CPU used: wavenet::WaveNet::_process_core_ [clone .localalias]
After:     617  96.6% wavenet::WaveNet::_process_core_ [clone .localalias]

Results were benchmarked in an LV2 plugin running on a Raspberry Pi 4, using the "BLUE GAIN 2" NAM preset, downloaded from ToneHunt.

I was unable to get coverage on the LSTM unit, in order to find uses of temporary matrixes, so the LSTM code hasn't received the same treatment. If you have an LSTM preset for NAM, I would be happy to do the same optimization for LSTMs. The temporary matrix allocations were caught by setting up the plugin, and running one cycle to get all the matrix allocations to finish. Then, I then set a breakpoint on `_int_malloc`.  And if it breaks, you can identify the offending operation by backtracing on the stack.




