### PR TITLE
Remove `nam::DSP::finalize_()`

### DIFF
--- a/NAM/convnet.cpp
+++ b/NAM/convnet.cpp
@@ -132,6 +132,9 @@ void nam::convnet::ConvNet::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const
   // Copy to required output array (TODO tighten this up)
   for (int s = 0; s < num_frames; s++)
     output[s] = this->_head_output(s);
+
+  // Prepare for next call:
+  nam::Buffer::_advance_input_buffer_(num_frames);
 }
 
 void nam::convnet::ConvNet::_verify_weights(const int channels, const std::vector<int>& dilations, const bool batchnorm,

--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -31,7 +31,6 @@ void nam::DSP::prewarm()
   for (long i = 0; i < _prewarm_samples; i++)
   {
     this->process(sample_ptr, sample_ptr, 1);
-    this->finalize_(1);
     sample = 0;
   }
 }
@@ -57,8 +56,6 @@ void nam::DSP::SetLoudness(const double loudness)
   mLoudness = loudness;
   mHasLoudness = true;
 }
-
-void nam::DSP::finalize_(const int num_frames) {}
 
 // Buffer =====================================================================
 
@@ -128,9 +125,8 @@ void nam::Buffer::_reset_input_buffer()
   this->_input_buffer_offset = this->_receptive_field;
 }
 
-void nam::Buffer::finalize_(const int num_frames)
+void nam::Buffer::_advance_input_buffer_(const int num_frames)
 {
-  this->nam::DSP::finalize_(num_frames);
   this->_input_buffer_offset += num_frames;
 }
 
@@ -163,6 +159,9 @@ void nam::Linear::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_f
     auto input = Eigen::Map<const Eigen::VectorXf>(&this->_input_buffer[offset], this->_receptive_field);
     output[i] = this->_bias + this->_weight.dot(input);
   }
+
+  // Prepare for next call:
+  nam::Buffer::_advance_input_buffer_(num_frames);
 }
 
 // NN modules =================================================================

--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -52,10 +52,6 @@ public:
   //    overridden in subclasses).
   // 2. The output level is applied and the result stored to `output`.
   virtual void process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_frames);
-  // Anything to take care of before next buffer comes in.
-  // For example:
-  // * Move the buffer index forward
-  virtual void finalize_(const int num_frames);
   // Expected sample rate, in Hz.
   // TODO throw if it doesn't know.
   double GetExpectedSampleRate() const { return mExpectedSampleRate; };
@@ -86,7 +82,6 @@ class Buffer : public DSP
 {
 public:
   Buffer(const int receptive_field, const double expected_sample_rate = -1.0);
-  void finalize_(const int num_frames);
 
 protected:
   // Input buffer
@@ -97,6 +92,7 @@ protected:
   std::vector<float> _input_buffer;
   std::vector<float> _output_buffer;
 
+  void _advance_input_buffer_(const int num_frames);
   void _set_receptive_field(const int new_receptive_field, const int input_buffer_size);
   void _set_receptive_field(const int new_receptive_field);
   void _reset_input_buffer();

--- a/NAM/wavenet.cpp
+++ b/NAM/wavenet.cpp
@@ -272,12 +272,6 @@ nam::wavenet::WaveNet::WaveNet(const std::vector<nam::wavenet::LayerArrayParams>
     _prewarm_samples += this->_layer_arrays[i].get_receptive_field();
 }
 
-void nam::wavenet::WaveNet::finalize_(const int num_frames)
-{
-  this->DSP::finalize_(num_frames);
-  this->_advance_buffers_(num_frames);
-}
-
 void nam::wavenet::WaveNet::set_weights_(std::vector<float>& weights)
 {
   std::vector<float>::iterator it = weights.begin();
@@ -347,6 +341,9 @@ void nam::wavenet::WaveNet::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const
     float out = this->_head_scale * this->_head_arrays[final_head_array](0, s);
     output[s] = out;
   }
+
+  // Finalize to rpepare for the next call:
+  this->_advance_buffers_(num_frames);
 }
 
 void nam::wavenet::WaveNet::_set_num_frames_(const long num_frames)

--- a/NAM/wavenet.h
+++ b/NAM/wavenet.h
@@ -171,7 +171,6 @@ public:
           std::vector<float> weights, const double expected_sample_rate = -1.0);
   ~WaveNet() = default;
 
-  void finalize_(const int num_frames) override;
   void set_weights_(std::vector<float>& weights);
 
 private:


### PR DESCRIPTION
## Description

Breaking change. Following this, Code calling NAM should not do ([e.g.](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/83fa931886f2fd0ab15e38d4bd5c5a9b23716717/NeuralAmpModeler/NeuralAmpModeler.cpp#L308)):

```cpp
model->process(input, output, numFrames);
model->finalize_(numFrames);
```

and instead just do

```cpp
model->process(input, output, numFrames);
```

And subclasses shall take care of any preparation for the next call to `process` themselves.

## Subclasses that don't override nor extend `DSP::finalize_()`:

* `Base`
* `Gain`
* `History`
* `LSTM`

## Subclasses where some change was needed:

* `Buffer`: This advanced the input buffer. Made an equivalent protected method `_advance_input_buffer_()` that subclasses can still use.
* `WaveNet`: Move `_advance_buffers_()` inside of `process`.

Subclasses of `Buffer` also needed to be checked:

* `ConvNet`: doesn't override, so `_advance_input_buffer_()` is pulled inside of `process()`
* `Linear`: Same

## Testing
I checked a render before and after using [a typical WaveNet](https://tonehunt.org/arsafes/b486d24a-dcbc-4623-9cb0-ccd5b5570f87) and ensured that they're the same.