### PR TITLE
[FEATURE] Ability to register new factories into `get_dsp()`

### DIFF
--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -7,6 +7,7 @@
 #include <unordered_set>
 
 #include "dsp.h"
+#include "registry.h"
 
 #define tanh_impl_ std::tanh
 // #define tanh_impl_ fast_tanh_
@@ -190,6 +191,13 @@ void nam::Linear::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_f
 
   // Prepare for next call:
   nam::Buffer::_advance_input_buffer_(num_frames);
+}
+
+// Register factories for instantiating DSP objects
+nam::FactoryRegistry& nam::FactoryRegistry::instance()
+{
+  static FactoryRegistry inst;
+  return inst;
 }
 
 // NN modules =================================================================

--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -193,13 +193,6 @@ void nam::Linear::process(NAM_SAMPLE* input, NAM_SAMPLE* output, const int num_f
   nam::Buffer::_advance_input_buffer_(num_frames);
 }
 
-// Register factories for instantiating DSP objects
-nam::FactoryRegistry& nam::FactoryRegistry::instance()
-{
-  static FactoryRegistry inst;
-  return inst;
-}
-
 // NN modules =================================================================
 
 void nam::Conv1D::set_weights_(std::vector<float>::iterator& weights)

--- a/NAM/get_dsp.cpp
+++ b/NAM/get_dsp.cpp
@@ -9,6 +9,7 @@
 #include "lstm.h"
 #include "convnet.h"
 #include "wavenet.h"
+#include "get_dsp.h"
 
 namespace nam
 {
@@ -103,12 +104,7 @@ std::unique_ptr<DSP> get_dsp(const std::filesystem::path config_filename, dspDat
   returnedConfig.config = j["config"];
   returnedConfig.metadata = j["metadata"];
   returnedConfig.weights = weights;
-  if (j.find("sample_rate") != j.end())
-    returnedConfig.expected_sample_rate = j["sample_rate"];
-  else
-  {
-    returnedConfig.expected_sample_rate = -1.0;
-  }
+  returnedConfig.expected_sample_rate = nam::get_sample_rate_from_nam_file(j);
 
   /*Copy to a new dsp_config object for get_dsp below,
    since not sure if weights actually get modified as being non-const references on some
@@ -192,4 +188,13 @@ std::unique_ptr<DSP> get_dsp(dspData& conf)
 
   return out;
 }
+
+double get_sample_rate_from_nam_file(const nlohmann::json& j)
+{
+  if (j.find("sample_rate") != j.end())
+    return j["sample_rate"];
+  else
+    return -1.0;
+}
+
 }; // namespace nam

--- a/NAM/get_dsp.h
+++ b/NAM/get_dsp.h
@@ -12,4 +12,13 @@ std::unique_ptr<DSP> get_dsp(dspData& conf);
 
 // Get NAM from a provided .nam file path and store its configuration in the provided conf
 std::unique_ptr<DSP> get_dsp(const std::filesystem::path config_filename, dspData& returnedConfig);
+
+// Get sample rate from a config json:
+double get_sample_rate(const nlohmann::json& j)
+{
+  if (j.find("sample_rate") != j.end())
+    return j["sample_rate"];
+  else
+    return -1.0;
+};
 }; // namespace nam

--- a/NAM/get_dsp.h
+++ b/NAM/get_dsp.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <fstream>
 
 #include "dsp.h"
@@ -13,12 +15,7 @@ std::unique_ptr<DSP> get_dsp(dspData& conf);
 // Get NAM from a provided .nam file path and store its configuration in the provided conf
 std::unique_ptr<DSP> get_dsp(const std::filesystem::path config_filename, dspData& returnedConfig);
 
-// Get sample rate from a config json:
-double get_sample_rate(const nlohmann::json& j)
-{
-  if (j.find("sample_rate") != j.end())
-    return j["sample_rate"];
-  else
-    return -1.0;
-};
+// Get sample rate from a .nam file
+// Returns -1 if not known (Really old .nam files)
+double get_sample_rate_from_nam_file(const nlohmann::json& j);
 }; // namespace nam

--- a/NAM/lstm.cpp
+++ b/NAM/lstm.cpp
@@ -1,8 +1,11 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <memory>
 
+#include "registry.h"
 #include "lstm.h"
+#include "get_dsp.h"
 
 nam::lstm::LSTMCell::LSTMCell(const int input_size, const int hidden_size, std::vector<float>::iterator& weights)
 {
@@ -101,4 +104,20 @@ float nam::lstm::LSTM::_process_sample(const float x)
   for (size_t i = 1; i < this->_layers.size(); i++)
     this->_layers[i].process_(this->_layers[i - 1].get_hidden_state());
   return this->_head_weight.dot(this->_layers[this->_layers.size() - 1].get_hidden_state()) + this->_head_bias;
+}
+
+// Factory to instantiate from nlohmann json
+std::unique_ptr<nam::DSP> nam::lstm::Factory(const nlohmann::json& config, std::vector<float>& weights,
+                                             const double expectedSampleRate)
+{
+  const int num_layers = config["num_layers"];
+  const int input_size = config["input_size"];
+  const int hidden_size = config["hidden_size"];
+  return std::make_unique<nam::lstm::LSTM>(num_layers, input_size, hidden_size, weights, expectedSampleRate);
+}
+
+// Register the factory
+namespace
+{
+static nam::factory::Helper _register_LSTM("LSTM", nam::lstm::Factory);
 }

--- a/NAM/lstm.cpp
+++ b/NAM/lstm.cpp
@@ -5,7 +5,6 @@
 
 #include "registry.h"
 #include "lstm.h"
-#include "get_dsp.h"
 
 nam::lstm::LSTMCell::LSTMCell(const int input_size, const int hidden_size, std::vector<float>::iterator& weights)
 {

--- a/NAM/lstm.h
+++ b/NAM/lstm.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <vector>
+#include <memory>
 
 #include <Eigen/Dense>
 
@@ -69,5 +70,10 @@ protected:
   // Since this is assumed to not be a parametric model, its shape should be (1,)
   Eigen::VectorXf _input;
 };
+
+// Factory to instantiate from nlohmann json
+std::unique_ptr<DSP> Factory(const nlohmann::json& config, std::vector<float>& weights,
+                             const double expectedSampleRate);
+
 }; // namespace lstm
 }; // namespace nam

--- a/NAM/registry.h
+++ b/NAM/registry.h
@@ -1,0 +1,63 @@
+#pragma once
+
+// Registry for DSP objects
+
+#include <string>
+#include <memory>
+#include <unordered_map>
+#include <functional>
+
+#include "dsp.h"
+
+namespace nam
+{
+namespace factory
+{
+// TODO get rid of weights and expectedSampleRate
+using FactoryFunction = std::function<std::unique_ptr<DSP>(const nlohmann::json&, std::vector<float>&, const double)>;
+
+// Register factories for instantiating DSP objects
+class FactoryRegistry
+{
+public:
+  static FactoryRegistry& instance()
+  {
+    static FactoryRegistry inst;
+    return inst;
+  }
+
+  void registerFactory(const std::string& key, FactoryFunction func)
+  {
+    // Assert that the key is not already registered
+    if (factories_.find(key) != factories_.end())
+    {
+      throw std::runtime_error("Factory already registered for key: " + key);
+    }
+    factories_[key] = func;
+  }
+
+  std::unique_ptr<DSP> create(const std::string& name, const nlohmann::json& config, std::vector<float>& weights,
+                              const double expectedSampleRate) const
+  {
+    auto it = factories_.find(name);
+    if (it != factories_.end())
+    {
+      return it->second(config, weights, expectedSampleRate);
+    }
+    throw std::runtime_error("Factory not found for name: " + name);
+  }
+
+private:
+  std::unordered_map<std::string, FactoryFunction> factories_;
+};
+
+// Registration helper. Use this to register your factories.
+struct Helper
+{
+  Helper(const std::string& name, FactoryFunction factory)
+  {
+    FactoryRegistry::instance().registerFactory(name, std::move(factory));
+  }
+};
+} // namespace factory
+} // namespace nam

--- a/NAM/version.h
+++ b/NAM/version.h
@@ -1,9 +1,6 @@
-#ifndef version_h
-#define version_h
+#pragma once
 
 // Make sure this matches NAM version in ../CMakeLists.txt!
 #define NEURAL_AMP_MODELER_DSP_VERSION_MAJOR 0
 #define NEURAL_AMP_MODELER_DSP_VERSION_MINOR 3
 #define NEURAL_AMP_MODELER_DSP_VERSION_PATCH 0
-
-#endif

--- a/NAM/wavenet.h
+++ b/NAM/wavenet.h
@@ -220,5 +220,9 @@ private:
   int mPrewarmSamples = 0; // Pre-compute during initialization
   int PrewarmSamples() override { return mPrewarmSamples; };
 };
+
+// Factory to instantiate from nlohmann json
+std::unique_ptr<DSP> Factory(const nlohmann::json& config, std::vector<float>& weights,
+                             const double expectedSampleRate);
 }; // namespace wavenet
 }; // namespace nam


### PR DESCRIPTION
TODO:
- [ ] ConvNet
- [ ] Linear

This refactors so that you don't need to change `get_dsp.cpp` every time you add a new architecture downstream :)

Resolves #150 