### PR TITLE
Added gating activation classes

### DIFF
--- a/NAM/activations.h
+++ b/NAM/activations.h
@@ -111,6 +111,15 @@ protected:
   static std::unordered_map<std::string, Activation*> _activations;
 };
 
+// identity function activation
+class ActivationIdentity : public nam::activations::Activation
+{
+public:
+  ActivationIdentity() = default;
+  ~ActivationIdentity() = default;
+  // Inherit the default apply methods which do nothing
+};
+
 class ActivationTanh : public Activation
 {
 public:

--- a/NAM/gating_activations.h
+++ b/NAM/gating_activations.h
@@ -22,23 +22,19 @@ public:
   // Inherit the default apply methods which do nothing (linear/identity)
 };
 
-// Static instance for default activation
-static IdentityActivation default_activation;
-
 class GatingActivation
 {
 public:
   /**
    * Constructor for GatingActivation
-   * @param input_act Activation function for input channels (default: linear)
-   * @param gating_act Activation function for gating channels (default: sigmoid)
+   * @param input_act Activation function for input channels
+   * @param gating_act Activation function for gating channels
    * @param input_channels Number of input channels (default: 1)
    * @param gating_channels Number of gating channels (default: 1)
    */
-  GatingActivation(activations::Activation* input_act = nullptr, activations::Activation* gating_act = nullptr,
-                   int input_channels = 1)
-  : input_activation(input_act ? input_act : &default_activation)
-  , gating_activation(gating_act ? gating_act : activations::Activation::get_activation("Sigmoid"))
+  GatingActivation(activations::Activation* input_act, activations::Activation* gating_act, int input_channels = 1)
+  : input_activation(input_act)
+  , gating_activation(gating_act)
   , num_channels(input_channels)
   {
     assert(num_channels > 0);
@@ -102,10 +98,9 @@ public:
    * @param blend_act Activation function for blending channels
    * @param input_channels Number of input channels
    */
-  BlendingActivation(activations::Activation* input_act = nullptr, activations::Activation* blend_act = nullptr,
-                     int input_channels = 1)
-  : input_activation(input_act ? input_act : &default_activation)
-  , blending_activation(blend_act ? blend_act : &default_activation)
+  BlendingActivation(activations::Activation* input_act, activations::Activation* blend_act, int input_channels = 1)
+  : input_activation(input_act)
+  , blending_activation(blend_act)
   , num_channels(input_channels)
   {
     if (num_channels <= 0)

--- a/tools/run_tests.cpp
+++ b/tools/run_tests.cpp
@@ -28,7 +28,7 @@ int main()
   test_activations::TestPReLU::test_core_function();
   test_activations::TestPReLU::test_per_channel_behavior();
   // This is enforced by an assert so it doesn't need to be tested
-  //test_activations::TestPReLU::test_wrong_number_of_channels();
+  // test_activations::TestPReLU::test_wrong_number_of_channels();
 
   test_dsp::test_construct();
   test_dsp::test_get_input_level();

--- a/tools/test/test_blending_detailed.cpp
+++ b/tools/test/test_blending_detailed.cpp
@@ -27,7 +27,9 @@ public:
     Eigen::MatrixXf output(2, 2); // 2 output channels, 2 samples
 
     // Test with default (linear) activations
-    nam::gating_activations::BlendingActivation blending_act(nullptr, nullptr, 2);
+    nam::activations::ActivationIdentity identity_act;
+    nam::activations::ActivationIdentity identity_blend_act;
+    nam::gating_activations::BlendingActivation blending_act(&identity_act, &identity_blend_act, 2);
     blending_act.apply(input, output);
 
     std::cout << "Blending with linear activations:" << std::endl;
@@ -45,7 +47,7 @@ public:
 
     // Test with sigmoid blending activation
     nam::activations::Activation* sigmoid_act = nam::activations::Activation::get_activation("Sigmoid");
-    nam::gating_activations::BlendingActivation blending_act_sigmoid(nullptr, sigmoid_act, 2);
+    nam::gating_activations::BlendingActivation blending_act_sigmoid(&identity_act, sigmoid_act, 2);
 
     Eigen::MatrixXf output_sigmoid(2, 2);
     blending_act_sigmoid.apply(input, output_sigmoid);
@@ -86,7 +88,8 @@ public:
 
     // Test with ReLU activation on input (which will change values < 0 to 0)
     nam::activations::ActivationReLU relu_act;
-    nam::gating_activations::BlendingActivation blending_act(&relu_act, nullptr, 1);
+    nam::activations::ActivationIdentity identity_act;
+    nam::gating_activations::BlendingActivation blending_act(&relu_act, &identity_act, 1);
 
     blending_act.apply(input, output);
 

--- a/tools/test/test_gating_activations.cpp
+++ b/tools/test/test_gating_activations.cpp
@@ -24,7 +24,9 @@ public:
     Eigen::MatrixXf output(1, 3);
 
     // Create gating activation with default activations (1 input channel, 1 gating channel)
-    nam::gating_activations::GatingActivation gating_act(nullptr, nullptr, 1);
+    nam::activations::ActivationIdentity identity_act;
+    nam::activations::ActivationSigmoid sigmoid_act;
+    nam::gating_activations::GatingActivation gating_act(&identity_act, &sigmoid_act, 1);
 
     // Apply the activation
     gating_act.apply(input, output);
@@ -84,7 +86,9 @@ public:
     Eigen::MatrixXf output(1, 3);
 
     // Create blending activation (1 input channel)
-    nam::gating_activations::BlendingActivation blending_act(nullptr, nullptr, 1);
+    nam::activations::ActivationIdentity identity_act;
+    nam::activations::ActivationIdentity identity_blend_act;
+    nam::gating_activations::BlendingActivation blending_act(&identity_act, &identity_blend_act, 1);
 
     // Apply the activation
     blending_act.apply(input, output);
@@ -106,7 +110,9 @@ public:
     Eigen::MatrixXf output(1, 2);
 
     // Test with default (linear) activations
-    nam::gating_activations::BlendingActivation blending_act(nullptr, nullptr, 1);
+    nam::activations::ActivationIdentity identity_act;
+    nam::activations::ActivationIdentity identity_blend_act;
+    nam::gating_activations::BlendingActivation blending_act(&identity_act, &identity_blend_act, 1);
     blending_act.apply(input, output);
 
     // With linear activations, blending should be:
@@ -118,7 +124,7 @@ public:
 
     // Test with sigmoid blending activation
     nam::activations::Activation* sigmoid_act = nam::activations::Activation::get_activation("Sigmoid");
-    nam::gating_activations::BlendingActivation blending_act2(nullptr, sigmoid_act, 1);
+    nam::gating_activations::BlendingActivation blending_act2(&identity_act, sigmoid_act, 1);
     blending_act2.apply(input, output);
 
     // With sigmoid blending, alpha values should be between 0 and 1
@@ -168,7 +174,9 @@ public:
     Eigen::MatrixXf input(1, 2); // Only 1 row
     Eigen::MatrixXf output(1, 2);
 
-    nam::gating_activations::BlendingActivation blending_act(nullptr, nullptr, 1);
+    nam::activations::ActivationIdentity identity_act;
+    nam::activations::ActivationIdentity identity_blend_act;
+    nam::gating_activations::BlendingActivation blending_act(&identity_act, &identity_blend_act, 1);
 
     // This should trigger an assert and terminate the program
     // We can't easily test asserts in a unit test framework without special handling
@@ -187,7 +195,9 @@ public:
 
     Eigen::MatrixXf output(1, 1);
 
-    nam::gating_activations::BlendingActivation blending_act(nullptr, nullptr, 1);
+    nam::activations::ActivationIdentity identity_act;
+    nam::activations::ActivationIdentity identity_blend_act;
+    nam::gating_activations::BlendingActivation blending_act(&identity_act, &identity_blend_act, 1);
     blending_act.apply(input, output);
 
     assert(fabs(output(0, 0) - 0.0f) < 1e-6);

--- a/tools/test/test_input_buffer_verification.cpp
+++ b/tools/test/test_input_buffer_verification.cpp
@@ -25,7 +25,8 @@ public:
 
     // Use ReLU activation which will set negative values to 0
     nam::activations::ActivationReLU relu_act;
-    nam::gating_activations::BlendingActivation blending_act(&relu_act, nullptr, 1);
+    nam::activations::ActivationIdentity identity_act;
+    nam::gating_activations::BlendingActivation blending_act(&relu_act, &identity_act, 1);
 
     // Apply the activation
     blending_act.apply(input, output);
@@ -59,7 +60,8 @@ public:
 
     // Use LeakyReLU with slope 0.1
     nam::activations::ActivationLeakyReLU leaky_relu(0.1f);
-    nam::gating_activations::BlendingActivation blending_act(&leaky_relu, nullptr, 1);
+    nam::activations::ActivationIdentity identity_act;
+    nam::gating_activations::BlendingActivation blending_act(&leaky_relu, &identity_act, 1);
 
     blending_act.apply(input, output);
 

--- a/tools/test/test_wavenet_gating_compatibility.cpp
+++ b/tools/test/test_wavenet_gating_compatibility.cpp
@@ -33,7 +33,9 @@ public:
 
     // Create gating activation that matches wavenet behavior
     // Wavenet uses: input activation (default/linear) and sigmoid for gating
-    nam::gating_activations::GatingActivation gating_act(nullptr, nullptr, channels);
+    nam::activations::ActivationIdentity identity_act;
+    nam::activations::ActivationSigmoid sigmoid_act;
+    nam::gating_activations::GatingActivation gating_act(&identity_act, &sigmoid_act, channels);
 
     // Apply the activation
     gating_act.apply(input, output);
@@ -82,7 +84,9 @@ public:
 
     Eigen::MatrixXf output(channels, num_samples);
 
-    nam::gating_activations::GatingActivation gating_act(nullptr, nullptr, channels);
+    nam::activations::ActivationIdentity identity_act;
+    nam::activations::ActivationSigmoid sigmoid_act;
+    nam::gating_activations::GatingActivation gating_act(&identity_act, &sigmoid_act, channels);
     gating_act.apply(input, output);
 
     // Verify each column was processed independently
@@ -118,7 +122,9 @@ public:
 
     Eigen::MatrixXf output(channels, num_samples);
 
-    nam::gating_activations::GatingActivation gating_act(nullptr, nullptr, channels);
+    nam::activations::ActivationIdentity identity_act;
+    nam::activations::ActivationSigmoid sigmoid_act;
+    nam::gating_activations::GatingActivation gating_act(&identity_act, &sigmoid_act, channels);
 
     // This should not crash or produce incorrect results due to memory contiguity issues
     gating_act.apply(input, output);
@@ -153,7 +159,9 @@ public:
 
     Eigen::MatrixXf output(channels, num_samples);
 
-    nam::gating_activations::GatingActivation gating_act(nullptr, nullptr, channels);
+    nam::activations::ActivationIdentity identity_act;
+    nam::activations::ActivationSigmoid sigmoid_act;
+    nam::gating_activations::GatingActivation gating_act(&identity_act, &sigmoid_act, channels);
     gating_act.apply(input, output);
 
     // Verify dimensions


### PR DESCRIPTION
Adding abstractions for gating activations and blending activations. These classes are both very similar: they take two activations (and a blending coefficient alpha for blending activations). One activation is used for channel 0 of the input (the "input activation" in the code) and the other is used for channel 1 (the "gating activation" in the code). The difference between the two is that gating activation uses the activation of the second channel as a gate, while blending activation sums both channels scaled by alpha and (1-alpha).

Developed with support and sponsorship from [TONE3000](https://www.tone3000.com/)