### PR TITLE
Add nam::Index alias and CI narrowing check

### DIFF
--- a/NAM/activations.h
+++ b/NAM/activations.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <Eigen/Dense>
+#include "index.h"
 
 #include "json.hpp"
 
@@ -273,21 +274,22 @@ public:
   void apply(Eigen::MatrixXf& matrix) override
   {
     // Matrix is organized as (channels, time_steps)
-    unsigned long actual_channels = static_cast<unsigned long>(matrix.rows());
+    const nam::Index actual_channels = matrix.rows();
 
     // Prepare the slopes for the current matrix size
     std::vector<float> slopes_for_channels = negative_slopes;
 
     // Fail loudly if input has more channels than activation
-    assert(actual_channels == negative_slopes.size());
+    assert((nam::Index)negative_slopes.size() == actual_channels);
 
     // Apply each negative slope to its corresponding channel
-    for (unsigned long channel = 0; channel < actual_channels; channel++)
+    for (nam::Index channel = 0; channel < actual_channels; ++channel)
     {
       // Apply the negative slope to all time steps in this channel
-      for (int time_step = 0; time_step < matrix.cols(); time_step++)
+      const nam::Index cols = matrix.cols();
+      for (nam::Index time_step = 0; time_step < cols; ++time_step)
       {
-        matrix(channel, time_step) = leaky_relu(matrix(channel, time_step), slopes_for_channels[channel]);
+        matrix(channel, time_step) = leaky_relu(matrix(channel, time_step), slopes_for_channels[(size_t)channel]);
       }
     }
   }

--- a/NAM/conv1d.cpp
+++ b/NAM/conv1d.cpp
@@ -21,11 +21,11 @@ void Conv1D::set_weights_(std::vector<float>::iterator& weights)
     // Crazy ordering because that's how it gets flattened.
     for (int g = 0; g < numGroups; g++)
     {
-      for (auto i = 0; i < out_per_group; i++)
+      for (long i = 0; i < out_per_group; ++i)
       {
-        for (auto j = 0; j < in_per_group; j++)
+        for (long j = 0; j < in_per_group; ++j)
         {
-          for (size_t k = 0; k < this->_weight.size(); k++)
+          for (size_t k = 0; k < this->_weight.size(); ++k)
           {
             this->_weight[k](g * out_per_group + i, g * in_per_group + j) = *(weights++);
           }
@@ -96,10 +96,10 @@ void Conv1D::SetMaxBufferSize(const int maxBufferSize)
 }
 
 
-void Conv1D::Process(const Eigen::MatrixXf& input, const int num_frames)
+void Conv1D::Process(const Eigen::MatrixXf& input, const nam::Index num_frames)
 {
   // Write input to ring buffer
-  _input_buffer.Write(input, num_frames);
+  _input_buffer.Write(input, (int)num_frames);
 
   // Zero output before processing
   _output.leftCols(num_frames).setZero();
@@ -124,7 +124,7 @@ void Conv1D::Process(const Eigen::MatrixXf& input, const int num_frames)
     {
       const long offset = this->_dilation * (k + 1 - (long)this->_weight.size());
       const long lookback = -offset;
-      auto input_block = _input_buffer.Read(num_frames, lookback);
+      auto input_block = _input_buffer.Read((int)num_frames, lookback);
       _output.leftCols(num_frames).noalias() += this->_weight[k] * input_block;
     }
   }
@@ -137,7 +137,7 @@ void Conv1D::Process(const Eigen::MatrixXf& input, const int num_frames)
       {
         const long offset = this->_dilation * (k + 1 - (long)this->_weight.size());
         const long lookback = -offset;
-        auto input_block = _input_buffer.Read(num_frames, lookback);
+        auto input_block = _input_buffer.Read((int)num_frames, lookback);
 
         // Extract input slice for this group
         auto input_group = input_block.middleRows(g * in_per_group, in_per_group);
@@ -161,7 +161,7 @@ void Conv1D::Process(const Eigen::MatrixXf& input, const int num_frames)
   }
 
   // Advance ring buffer write pointer after processing
-  _input_buffer.Advance(num_frames);
+  _input_buffer.Advance((int)num_frames);
 }
 
 void Conv1D::process_(const Eigen::MatrixXf& input, Eigen::MatrixXf& output, const long i_start, const long ncols,

--- a/NAM/conv1d.h
+++ b/NAM/conv1d.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include "index.h"
 #include <vector>
 #include "ring_buffer.h"
 
@@ -80,7 +81,7 @@ public:
   /// \brief Process input and write to internal output buffer
   /// \param input Input matrix (channels x num_frames)
   /// \param num_frames Number of frames to process
-  void Process(const Eigen::MatrixXf& input, const int num_frames);
+  void Process(const Eigen::MatrixXf& input, const nam::Index num_frames);
 
   /// \brief Process from input to output (legacy method, kept for compatibility)
   ///

--- a/NAM/convnet.cpp
+++ b/NAM/convnet.cpp
@@ -68,7 +68,7 @@ void nam::convnet::ConvNetBlock::SetMaxBufferSize(const int maxBufferSize)
   this->_output.setZero();
 }
 
-void nam::convnet::ConvNetBlock::Process(const Eigen::MatrixXf& input, const int num_frames)
+void nam::convnet::ConvNetBlock::Process(const Eigen::MatrixXf& input, const nam::Index num_frames)
 {
   // Process input with Conv1D
   this->conv.Process(input, num_frames);
@@ -83,14 +83,14 @@ void nam::convnet::ConvNetBlock::Process(const Eigen::MatrixXf& input, const int
   if (this->_batchnorm)
   {
     // Batchnorm expects indices, so we use 0 to num_frames for our output matrix
-    this->batchnorm.process_(this->_output, 0, num_frames);
+    this->batchnorm.process_(this->_output, 0, (long)num_frames);
   }
 
   // Apply activation
   this->activation->apply(this->_output.leftCols(num_frames));
 }
 
-Eigen::Block<Eigen::MatrixXf> nam::convnet::ConvNetBlock::GetOutput(const int num_frames)
+Eigen::Block<Eigen::MatrixXf> nam::convnet::ConvNetBlock::GetOutput(const nam::Index num_frames)
 {
   return this->_output.block(0, 0, this->_output.rows(), num_frames);
 }

--- a/NAM/convnet.h
+++ b/NAM/convnet.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <Eigen/Dense>
+#include "index.h"
 
 #include "activations.h"
 #include "conv1d.h"
@@ -78,7 +79,7 @@ public:
   /// \brief Process input matrix directly (new API, similar to WaveNet)
   /// \param input Input matrix (channels x num_frames)
   /// \param num_frames Number of frames to process
-  void Process(const Eigen::MatrixXf& input, const int num_frames);
+  void Process(const Eigen::MatrixXf& input, const nam::Index num_frames);
 
   /// \brief Process input (legacy method for compatibility, uses indices)
   /// \param input Input matrix
@@ -90,7 +91,7 @@ public:
   /// \brief Get output from last Process() call
   /// \param num_frames Number of frames to return
   /// \return Block reference to the output
-  Eigen::Block<Eigen::MatrixXf> GetOutput(const int num_frames);
+  Eigen::Block<Eigen::MatrixXf> GetOutput(const nam::Index num_frames);
 
   /// \brief Get the number of output channels
   /// \return Number of output channels

--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -36,7 +36,7 @@ void nam::DSP::prewarm()
   if (prewarmSamples == 0)
     return;
 
-  const size_t bufferSize = std::max(mMaxBufferSize, 1);
+  const int bufferSize = std::max(mMaxBufferSize, 1);
   // Allocate buffers for all channels
   std::vector<std::vector<NAM_SAMPLE>> inputBuffers(mInChannels);
   std::vector<std::vector<NAM_SAMPLE>> outputBuffers(mOutChannels);
@@ -45,12 +45,12 @@ void nam::DSP::prewarm()
 
   for (int ch = 0; ch < mInChannels; ch++)
   {
-    inputBuffers[ch].resize(bufferSize, (NAM_SAMPLE)0.0);
+    inputBuffers[ch].resize((size_t)bufferSize, (NAM_SAMPLE)0.0);
     inputPtrs[ch] = inputBuffers[ch].data();
   }
   for (int ch = 0; ch < mOutChannels; ch++)
   {
-    outputBuffers[ch].resize(bufferSize, (NAM_SAMPLE)0.0);
+    outputBuffers[ch].resize((size_t)bufferSize, (NAM_SAMPLE)0.0);
     outputPtrs[ch] = outputBuffers[ch].data();
   }
 
@@ -368,17 +368,17 @@ void nam::Conv1x1::set_weights_(std::vector<float>::iterator& weights)
     }
   }
   if (this->_do_bias)
-    for (int i = 0; i < this->_bias.size(); i++)
+    for (nam::Index i = 0; i < (nam::Index)this->_bias.size(); ++i)
       this->_bias(i) = *(weights++);
 }
 
-Eigen::MatrixXf nam::Conv1x1::process(const Eigen::MatrixXf& input, const int num_frames) const
+Eigen::MatrixXf nam::Conv1x1::process(const Eigen::MatrixXf& input, const nam::Index num_frames) const
 {
   const int numGroups = this->_num_groups;
-  const long in_channels = get_in_channels();
-  const long out_channels = get_out_channels();
-  const long in_per_group = in_channels / numGroups;
-  const long out_per_group = out_channels / numGroups;
+  const nam::Index in_channels = get_in_channels();
+  const nam::Index out_channels = get_out_channels();
+  const nam::Index in_per_group = in_channels / numGroups;
+  const nam::Index out_per_group = out_channels / numGroups;
 
   Eigen::MatrixXf result(out_channels, num_frames);
 
@@ -394,7 +394,7 @@ Eigen::MatrixXf nam::Conv1x1::process(const Eigen::MatrixXf& input, const int nu
   {
     // Grouped convolution: process each group separately
     result.setZero();
-    for (int g = 0; g < numGroups; g++)
+    for (int g = 0; g < numGroups; ++g)
     {
       // Extract input slice for this group
       auto input_group = input.leftCols(num_frames).middleRows(g * in_per_group, in_per_group);

--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <Eigen/Dense>
+#include "index.h"
 
 #include "activations.h"
 #include "json.hpp"
@@ -307,13 +308,13 @@ public:
   ///
   /// \param input Input matrix (channels x num_frames) or (channels,)
   /// \return Output matrix (channels x num_frames) or (channels,), respectively
-  Eigen::MatrixXf process(const Eigen::MatrixXf& input) const { return process(input, (int)input.cols()); };
+  Eigen::MatrixXf process(const Eigen::MatrixXf& input) const { return process(input, (nam::Index)input.cols()); };
 
   /// \brief Process input and return output matrix
   /// \param input Input matrix (channels x num_frames)
   /// \param num_frames Number of frames to process
   /// \return Output matrix (channels x num_frames)
-  Eigen::MatrixXf process(const Eigen::MatrixXf& input, const int num_frames) const;
+  Eigen::MatrixXf process(const Eigen::MatrixXf& input, const nam::Index num_frames) const;
 
   /// \brief Process input and store output to pre-allocated buffer
   ///

--- a/NAM/gating_activations.h
+++ b/NAM/gating_activations.h
@@ -4,6 +4,7 @@
 #include <cmath> // expf
 #include <unordered_map>
 #include <Eigen/Dense>
+#include "index.h"
 #include <functional>
 #include <stdexcept>
 #include "activations.h"
@@ -66,8 +67,8 @@ public:
 
     // Process column-by-column to ensure memory contiguity (important for column-major matrices)
     // Uses pre-allocated buffers to avoid allocations in the loop (real-time safe)
-    const int num_samples = input.cols();
-    for (int i = 0; i < num_samples; i++)
+    const nam::Index num_samples = input.cols();
+    for (nam::Index i = 0; i < num_samples; ++i)
     {
       // Copy to pre-allocated buffers and apply activations in-place
       input_buffer = input.block(0, i, num_channels, 1);
@@ -142,8 +143,8 @@ public:
 
     // Process column-by-column to ensure memory contiguity
     // Uses pre-allocated buffers to avoid allocations in the loop (real-time safe)
-    const int num_samples = input.cols();
-    for (int i = 0; i < num_samples; i++)
+    const nam::Index num_samples = input.cols();
+    for (nam::Index i = 0; i < num_samples; ++i)
     {
       // Store pre-activation input values in buffer
       pre_activation_buffer = input.block(0, i, num_channels, 1);

--- a/NAM/index.h
+++ b/NAM/index.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <Eigen/Core>
+
+namespace nam {
+  /// Central, project-wide alias for Eigen index type. Use this for matrix indexing loops.
+  using Index = Eigen::Index;
+}

--- a/NAM/lstm.cpp
+++ b/NAM/lstm.cpp
@@ -16,15 +16,15 @@ nam::lstm::LSTMCell::LSTMCell(const int input_size, const int hidden_size, std::
   this->_c.resize(hidden_size);
 
   // Assign in row-major because that's how PyTorch goes.
-  for (int i = 0; i < this->_w.rows(); i++)
-    for (int j = 0; j < this->_w.cols(); j++)
+  for (nam::Index i = 0; i < this->_w.rows(); ++i)
+    for (nam::Index j = 0; j < this->_w.cols(); ++j)
       this->_w(i, j) = *(weights++);
-  for (int i = 0; i < this->_b.size(); i++)
+  for (nam::Index i = 0; i < (nam::Index)this->_b.size(); ++i)
     this->_b[i] = *(weights++);
-  const int h_offset = input_size;
-  for (int i = 0; i < hidden_size; i++)
+  const nam::Index h_offset = input_size;
+  for (nam::Index i = 0; i < hidden_size; ++i)
     this->_xh[i + h_offset] = *(weights++);
-  for (int i = 0; i < hidden_size; i++)
+  for (nam::Index i = 0; i < hidden_size; ++i)
     this->_c[i] = *(weights++);
 }
 
@@ -45,22 +45,22 @@ void nam::lstm::LSTMCell::process_(const Eigen::VectorXf& x)
 
   if (activations::Activation::using_fast_tanh)
   {
-    for (auto i = 0; i < hidden_size; i++)
+    for (nam::Index i = 0; i < hidden_size; ++i)
       this->_c[i] =
         activations::fast_sigmoid(this->_ifgo[i + f_offset]) * this->_c[i]
         + activations::fast_sigmoid(this->_ifgo[i + i_offset]) * activations::fast_tanh(this->_ifgo[i + g_offset]);
 
-    for (int i = 0; i < hidden_size; i++)
+    for (nam::Index i = 0; i < hidden_size; ++i)
       this->_xh[i + h_offset] =
         activations::fast_sigmoid(this->_ifgo[i + o_offset]) * activations::fast_tanh(this->_c[i]);
   }
   else
   {
-    for (auto i = 0; i < hidden_size; i++)
+    for (nam::Index i = 0; i < hidden_size; ++i)
       this->_c[i] = activations::sigmoid(this->_ifgo[i + f_offset]) * this->_c[i]
                     + activations::sigmoid(this->_ifgo[i + i_offset]) * tanhf(this->_ifgo[i + g_offset]);
 
-    for (int i = 0; i < hidden_size; i++)
+    for (nam::Index i = 0; i < hidden_size; ++i)
       this->_xh[i + h_offset] = activations::sigmoid(this->_ifgo[i + o_offset]) * tanhf(this->_c[i]);
   }
 }

--- a/NAM/ring_buffer.cpp
+++ b/NAM/ring_buffer.cpp
@@ -4,7 +4,7 @@
 namespace nam
 {
 
-void RingBuffer::Reset(const int channels, const int max_buffer_size)
+void RingBuffer::Reset(const long channels, const int max_buffer_size)
 {
   // Store the max buffer size for external queries
   _max_buffer_size = max_buffer_size;
@@ -15,13 +15,13 @@ void RingBuffer::Reset(const int channels, const int max_buffer_size)
   // - max_buffer_size in the middle (for writes/reads)
   // - no aliasing when rewinding
   const long storage_size = 2 * _max_lookback + max_buffer_size;
-  _storage.resize(channels, storage_size);
+  _storage.resize((nam::Index)channels, (nam::Index)storage_size);
   _storage.setZero();
   // Initialize write position to max_lookback to leave room for history
   // Zero the storage behind the starting write position (for lookback)
   if (_max_lookback > 0)
   {
-    _storage.leftCols(_max_lookback).setZero();
+    _storage.leftCols((nam::Index)_max_lookback).setZero();
   }
   _write_pos = _max_lookback;
 }
@@ -41,12 +41,12 @@ void RingBuffer::Write(const Eigen::MatrixXf& input, const int num_frames)
   //       expressions across the API boundary; instead, pass the full buffer and
   //       slice inside the callee. This avoids Eigen evaluating Blocks into
   //       temporaries (which would allocate) when binding to MatrixXf.
-  const int channels = _storage.rows();
+  const long channels = _storage.rows();
   const int copy_cols = num_frames;
 
   for (int col = 0; col < copy_cols; ++col)
   {
-    for (int row = 0; row < channels; ++row)
+    for (long row = 0; row < channels; ++row)
     {
       _storage(row, _write_pos + col) = input(row, col);
     }

--- a/NAM/ring_buffer.h
+++ b/NAM/ring_buffer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include "index.h"
 
 namespace nam
 {
@@ -17,7 +18,7 @@ public:
   /// \brief Initialize/resize storage
   /// \param channels Number of channels (rows in the storage matrix)
   /// \param max_buffer_size Maximum amount that will be written or read at once
-  void Reset(const int channels, const int max_buffer_size);
+  void Reset(const long channels, const int max_buffer_size);
 
   /// \brief Write new data at write pointer
   ///
@@ -46,7 +47,7 @@ public:
 
   /// \brief Get number of channels (rows)
   /// \return Number of channels
-  int GetChannels() const { return _storage.rows(); }
+  long GetChannels() const { return (long)_storage.rows(); }
 
   /// \brief Set the max lookback (maximum history needed when rewinding)
   /// \param max_lookback Maximum lookback distance


### PR DESCRIPTION
Add a central  alias (alias of ) and convert hotspot files to use it. Adds  explaining usage and  (CI script) that builds and fails on implicit narrowing/shorten warnings. This helps prevent implicit-index-narrowing regressions and centralizes the index type for future portability.\n\nChanges: NAM/index.h, multiple NAM/* files updated to use , docs and CI script added.