### PR TITLE
[BUGFIX] WaveNet Factory: Check that condition_dsp is not null

### DIFF
--- a/NAM/wavenet.cpp
+++ b/NAM/wavenet.cpp
@@ -573,7 +573,7 @@ std::unique_ptr<nam::DSP> nam::wavenet::Factory(const nlohmann::json& config, st
                                                 const double expectedSampleRate)
 {
   std::unique_ptr<nam::DSP> condition_dsp = nullptr;
-  if (config.find("condition_dsp") != config.end())
+  if (config.find("condition_dsp") != config.end() && !config["condition_dsp"].is_null())
   {
     const nlohmann::json& condition_dsp_json = config["condition_dsp"];
     condition_dsp = nam::get_dsp(condition_dsp_json);


### PR DESCRIPTION
Quick bugfix. We already did that for head, but forgot to do it for condition_dsp.

Developed with support and sponsorship from [TONE3000](https://www.tone3000.com/)