### PR TITLE
[BUGFIX, BREAKING] Make activation base class abstract, fix PReLU implementation

### DIFF
--- a/NAM/activations.h
+++ b/NAM/activations.h
@@ -2,7 +2,8 @@
 
 #include <cassert>
 #include <cmath> // expf
-#include <iostream> // std::cerr
+#include <iostream> // std::cerr (kept for potential debug use)
+#include <stdexcept> // std::invalid_argument
 #include <functional>
 #include <memory>
 #include <optional>
@@ -283,10 +284,9 @@ public:
 #ifndef NDEBUG
     if (size % negative_slopes.size() != 0)
     {
-      std::cerr << "PReLU.apply(*data, size) was given an array of size " << size
-                << " but the activation has " << negative_slopes.size()
-                << " channels, which doesn't divide evenly.\n";
-      assert(false);
+      throw std::invalid_argument("PReLU.apply(*data, size) was given an array of size " + std::to_string(size)
+                                  + " but the activation has " + std::to_string(negative_slopes.size())
+                                  + " channels, which doesn't divide evenly.");
     }
 #endif
     for (long pos = 0; pos < size; pos++)
@@ -308,9 +308,9 @@ public:
 #ifndef NDEBUG
     if (actual_channels != negative_slopes.size())
     {
-      std::cerr << "PReLU: Received " << actual_channels << " channels, but activation has "
-                << negative_slopes.size() << " channels\n";
-      assert(false);
+      throw std::invalid_argument("PReLU: Received " + std::to_string(actual_channels)
+                                  + " channels, but activation has " + std::to_string(negative_slopes.size())
+                                  + " channels");
     }
 #endif
 

--- a/tools/run_tests.cpp
+++ b/tools/run_tests.cpp
@@ -48,8 +48,9 @@ int main()
 
   test_activations::TestPReLU::test_core_function();
   test_activations::TestPReLU::test_per_channel_behavior();
-  // This is enforced by an assert so it doesn't need to be tested
-  // test_activations::TestPReLU::test_wrong_number_of_channels();
+  test_activations::TestPReLU::test_wrong_number_of_channels_matrix();
+  test_activations::TestPReLU::test_wrong_size_array();
+  test_activations::TestPReLU::test_valid_array_size();
 
   // Typed ActivationConfig tests
   test_activations::TestTypedActivationConfig::test_simple_config();


### PR DESCRIPTION
Fixes an issue where PReLU was (wrongly, silently) falling back to a no-op default.

Unfortunately, the `apply(*data, size)` signature is a bad choice for generalized activations like PReLU, where the shape of the array ought to be specifically matched. This adds to my other gripes like the contiguous-memory assumption that was the root cause of #101 

Added tests that assert that the known unhappy path is caught.

Breaking change (w.r.t. v0.3) is that the base class is now abstract.