### PR TITLE
Fix MSVC build ("__restrict__" keyword)

### DIFF
--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -21,6 +21,10 @@
 /// \brief Use a sample rate of -1 if we don't know what the model expects to be run at
 #define NAM_UNKNOWN_EXPECTED_SAMPLE_RATE -1.0
 
+#if defined(_MSC_VER) && !defined(__llvm__) 
+#define __restrict__ __restrict
+#endif
+
 namespace nam
 {
 namespace wavenet


### PR DESCRIPTION
The latest NAM Core doesn't build with Visual Studio because the "__restrict__" keyword is different ("__restrict").

This fixes things with an MSVC-specific #define.