### PR TITLE
[FEATURE] A2 fast-path WaveNet for A2 nano + A2 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,15 @@ endif()
 set(NAM_DEPS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/Dependencies")
 include_directories(SYSTEM "${NAM_DEPS_PATH}/eigen")
 
+# Build the specialized A2 fast-path WaveNet (A2 standard + A2 nano). When ON,
+# models whose config matches the A2 shape signature are routed to a hand-optimized
+# WaveNet implementation instead of the generic one. When OFF, all models go
+# through the generic path.
+option(NAM_ENABLE_A2_FAST "Build the A2 fast-path WaveNet" ON)
+if(NAM_ENABLE_A2_FAST)
+	add_compile_definitions(NAM_ENABLE_A2_FAST)
+endif()
+
 add_subdirectory(tools)
 
 #file(MAKE_DIRECTORY build/tools)

--- a/NAM/wavenet/a2_fast.cpp
+++ b/NAM/wavenet/a2_fast.cpp
@@ -134,6 +134,8 @@ private:
   std::vector<float> _layer_in; // current layer input / next layer input (in-place residual)
   std::vector<float> _head_sum; // accumulates activations across all layers
   std::vector<float> _z;        // per-layer conv output accumulator (tap-major)
+  std::vector<float> _cond;     // float32 copy of the double NAM_SAMPLE input, reused each block
+  std::vector<float> _head_out; // float32 head output before writing to NAM_SAMPLE
 
   int _prewarm_samples = 0;
 
@@ -290,6 +292,8 @@ void A2FastModel<Channels>::SetMaxBufferSize(int maxBufferSize)
   _layer_in.assign(static_cast<size_t>(Channels) * maxBufferSize, 0.0f);
   _head_sum.assign(static_cast<size_t>(Channels) * maxBufferSize, 0.0f);
   _z.assign(static_cast<size_t>(Channels) * maxBufferSize, 0.0f);
+  _cond.assign(static_cast<size_t>(maxBufferSize), 0.0f);
+  _head_out.assign(static_cast<size_t>(maxBufferSize), 0.0f);
 
   for (auto& L : _layers)
   {
@@ -690,7 +694,7 @@ void A2FastModel<Channels>::process(NAM_SAMPLE** input, NAM_SAMPLE** output, int
 
   // Rechannel: layer_in[c, f] = _rechannel_w[c] * input[f] for c in Channels.
   // Also prepare float cond buffer (input copied to float for inner loops).
-  std::vector<float> cond(num_frames);
+  float* cond = _cond.data();
   for (int f = 0; f < num_frames; f++)
   {
     const float x = static_cast<float>(in0[f]);
@@ -704,11 +708,11 @@ void A2FastModel<Channels>::process(NAM_SAMPLE** input, NAM_SAMPLE** output, int
   std::memset(_head_sum.data(), 0, static_cast<size_t>(num_frames) * Channels * sizeof(float));
 
   for (int li = 0; li < kNumLayers; li++)
-    _layer_forward(li, cond.data(), num_frames);
+    _layer_forward(li, cond, num_frames);
 
   // Output.
-  std::vector<float> head_out(num_frames);
-  _head_forward(head_out.data(), num_frames);
+  float* head_out = _head_out.data();
+  _head_forward(head_out, num_frames);
   for (int f = 0; f < num_frames; f++)
     out0[f] = static_cast<NAM_SAMPLE>(head_out[f]);
 }

--- a/NAM/wavenet/a2_fast.cpp
+++ b/NAM/wavenet/a2_fast.cpp
@@ -1,0 +1,932 @@
+#if defined(NAM_ENABLE_A2_FAST)
+
+// Ring-buffer strategy:
+//   0 = linear memmove-rewind (variable worst-case latency, sporadic spikes)
+//   1 = pow2 + tail mirror (constant per-block work, branchless reads)
+// Controlled externally with -DNAM_A2_RING_MODE=0 for head-to-head comparison.
+#ifndef NAM_A2_RING_MODE
+#define NAM_A2_RING_MODE 1
+#endif
+
+#include "a2_fast.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "../dsp.h"
+
+namespace nam
+{
+namespace wavenet
+{
+namespace a2_fast
+{
+
+namespace
+{
+
+// =============================================================================
+// A2FastModel<Channels>
+//
+// Skeleton implementation: correct but not yet optimized.
+//
+// Architectural invariants (checked once by is_a2_shape before we get here):
+//   - single layer array with 23 layers
+//   - Bottleneck == Channels
+//   - condition_size == input_size == out_channels == 1
+//   - LeakyReLU(0.01) on every layer, no gating, no FiLM, no head1x1
+//   - layer1x1 active (groups=1), head rechannel conv k=16 bias=true
+//   - head_scale == 0.01, no post-stack head
+//
+// Weight storage: column-major per kernel tap. For a (out_ch × in_ch) matrix
+// at tap k, element (row=i, col=j) lives at w[k][j * out_ch + i]. All 1×1
+// and K×1 convolutions follow the same convention (with K = 1 for 1×1).
+// =============================================================================
+template <int Channels>
+class A2FastModel : public DSP
+{
+public:
+  static constexpr int kChannels = Channels;
+  static constexpr int kBottleneck = Channels;
+  static constexpr int kHeadIn = Channels;
+
+  A2FastModel(std::vector<float> weights, double expected_sample_rate);
+  ~A2FastModel() override = default;
+
+  void process(NAM_SAMPLE** input, NAM_SAMPLE** output, int num_frames) override;
+
+protected:
+  void SetMaxBufferSize(int maxBufferSize) override;
+  int PrewarmSamples() override { return _prewarm_samples; }
+
+private:
+  struct Layer
+  {
+    int kernel_size = 0;
+    int dilation = 0;
+    int max_lookback = 0; // (kernel_size - 1) * dilation
+
+    // Dilated conv (Channels -> Bottleneck), column-major per tap.
+    // Flat size = kernel_size * Channels * Bottleneck.
+    std::vector<float> conv_w;
+    std::array<float, Channels> conv_b{};
+
+    // Input mixin (cond_size=1 -> Bottleneck), no bias.
+    std::array<float, Channels> mixin_w{};
+
+    // layer1x1 (Bottleneck -> Channels), with bias. Column-major (Channels × Bottleneck).
+    std::array<float, Channels * Channels> l1x1_w{};
+    std::array<float, Channels> l1x1_b{};
+
+    // Conv1D input history ring buffer, column-major (Channels rows).
+    std::vector<float> history;
+#if NAM_A2_RING_MODE == 1
+    // pow2 ring + tail mirror. Storage = (pow2_size + max_buffer_size) cols.
+    // write_pos is kept in [0, pow2_size), reads use (pos & pow2_mask) and are
+    // always contiguous because cols [pow2_size, pow2_size + max_buffer_size)
+    // mirror cols [0, max_buffer_size).
+    int pow2_size = 0;
+    int pow2_mask = 0;
+    int write_pos = 0;
+#else
+    // Linear ring with sporadic memmove-rewind. history_cols = 2*max_lookback +
+    // max_buffer_size; write_pos grows monotonically until rewind fires.
+    int history_cols = 0;
+    int write_pos = 0;
+#endif
+  };
+
+  std::array<Layer, kNumLayers> _layers;
+
+  // Rechannel (input_size=1 -> Channels), no bias.
+  std::array<float, Channels> _rechannel_w{};
+
+  // Head rechannel (Bottleneck -> 1), kernel=16, bias. Column-major per tap.
+  // At each tap, matrix is (1 × Channels) col-major -> Channels floats.
+  std::array<std::array<float, Channels>, kHeadKernelSize> _head_w{};
+  float _head_b = 0.0f;
+
+  // Head scale is stored as the trailing float in the weights stream (the generic
+  // WaveNet reads it the same way, overriding the JSON head_scale field).
+  float _head_scale = kHeadScale;
+
+  // Head ring buffer (Channels rows, col-major). Same ring layout as per-layer.
+  std::vector<float> _head_history;
+#if NAM_A2_RING_MODE == 1
+  int _head_pow2_size = 0;
+  int _head_pow2_mask = 0;
+  int _head_write_pos = 0;
+#else
+  int _head_history_cols = 0;
+  int _head_write_pos = 0;
+#endif
+
+  // Working buffers (all Channels rows, max_buffer_size cols, col-major).
+  std::vector<float> _layer_in; // current layer input / next layer input (in-place residual)
+  std::vector<float> _head_sum; // accumulates activations across all layers
+  std::vector<float> _z;        // per-layer conv output accumulator (tap-major)
+
+  int _prewarm_samples = 0;
+
+  void _load_weights(std::vector<float>& weights);
+  void _ring_write(Layer& L, int num_frames);
+  void _head_ring_write(int num_frames);
+  void _layer_forward(int layer_idx, const float* cond, int num_frames);
+  void _head_forward(float* output, int num_frames);
+
+  // Compile-time-specialized per-layer kernel. KernelSize is lifted to a
+  // template parameter so clang can fully unroll the tap loop and schedule
+  // FMAs across taps. For the A2 shape we only need K=6 and K=15.
+  template <int KernelSize>
+  void _layer_forward_k(Layer& L, const float* cond, int num_frames);
+};
+
+// -----------------------------------------------------------------------------
+// Construction
+// -----------------------------------------------------------------------------
+template <int Channels>
+A2FastModel<Channels>::A2FastModel(std::vector<float> weights, double expected_sample_rate)
+: DSP(/*in_channels=*/1, /*out_channels=*/1, expected_sample_rate)
+{
+  for (int i = 0; i < kNumLayers; i++)
+  {
+    _layers[i].kernel_size = kKernelSizes[i];
+    _layers[i].dilation = kDilations[i];
+    _layers[i].max_lookback = (kKernelSizes[i] - 1) * kDilations[i];
+    _layers[i].conv_w.assign(static_cast<size_t>(kKernelSizes[i]) * Channels * Channels, 0.0f);
+  }
+
+  _load_weights(weights);
+
+  int prewarm = 0;
+  for (int i = 0; i < kNumLayers; i++)
+    prewarm += _layers[i].max_lookback;
+  prewarm += kHeadKernelSize - 1;
+  _prewarm_samples = prewarm;
+}
+
+// -----------------------------------------------------------------------------
+// Weight loader
+//
+// Reproduces the generic path's weight-reading order exactly:
+//   - LayerArray::set_weights_:
+//       _rechannel (Conv1x1 1 -> Channels, no bias)
+//       for each layer:
+//           _conv (Conv1D Channels -> Bottleneck, K × C × B + B bias)
+//           _input_mixin (Conv1x1 1 -> Bottleneck, no bias)
+//           _layer1x1 (Conv1x1 Bottleneck -> Channels, with bias)
+//       _head_rechannel (Conv1D Bottleneck -> 1, K=16, bias)
+//
+// Generic Conv1D loader order: for i in out_ch: for j in in_ch: for k in taps.
+// Generic Conv1x1 loader order: for i in out_ch: for j in in_ch.
+// We permute into column-major per-tap storage while reading.
+// -----------------------------------------------------------------------------
+template <int Channels>
+void A2FastModel<Channels>::_load_weights(std::vector<float>& weights)
+{
+  auto it = weights.begin();
+  const auto end = weights.end();
+
+  auto take = [&]() -> float {
+    if (it == end)
+      throw std::runtime_error("A2FastModel: weight stream exhausted");
+    return *it++;
+  };
+
+  // Rechannel: 1 -> Channels, no bias. Read order: for i in Channels: for j in 1.
+  for (int i = 0; i < Channels; i++)
+    _rechannel_w[i] = take();
+
+  for (int li = 0; li < kNumLayers; li++)
+  {
+    Layer& L = _layers[li];
+    const int K = L.kernel_size;
+
+    // Conv1D: Channels -> Bottleneck, kernel=K, bias.
+    // Read order: for i in Bottleneck: for j in Channels: for k in K.
+    // Store at conv_w[k * C * B + j * B + i] (col-major (B × C) per tap).
+    for (int i = 0; i < Channels; i++) // row (out)
+    {
+      for (int j = 0; j < Channels; j++) // col (in)
+      {
+        for (int k = 0; k < K; k++)
+        {
+          L.conv_w[k * Channels * Channels + j * Channels + i] = take();
+        }
+      }
+    }
+    for (int i = 0; i < Channels; i++)
+      L.conv_b[i] = take();
+
+    // Input mixin: 1 -> Bottleneck, no bias. Read order: for i in Bottleneck: for j in 1.
+    for (int i = 0; i < Channels; i++)
+      L.mixin_w[i] = take();
+
+    // layer1x1: Bottleneck -> Channels, with bias. Read order: for i in Channels: for j in Bottleneck.
+    // Store at l1x1_w[j * Channels + i] (col-major Channels × Bottleneck).
+    for (int i = 0; i < Channels; i++) // row (out = Channels)
+    {
+      for (int j = 0; j < Channels; j++) // col (in = Bottleneck)
+      {
+        L.l1x1_w[j * Channels + i] = take();
+      }
+    }
+    for (int i = 0; i < Channels; i++)
+      L.l1x1_b[i] = take();
+  }
+
+  // Head rechannel: Bottleneck -> 1, kernel=16, bias.
+  // Read order: for i in 1: for j in Bottleneck: for k in 16.
+  // Store at _head_w[k][j] (row=0 since out=1, column-major => just Channels floats per tap).
+  for (int j = 0; j < Channels; j++)
+  {
+    for (int k = 0; k < kHeadKernelSize; k++)
+    {
+      _head_w[k][j] = take();
+    }
+  }
+  _head_b = take();
+
+  // Matches WaveNet::set_weights_: the last value in the stream is head_scale.
+  _head_scale = take();
+
+  if (it != end)
+  {
+    std::stringstream ss;
+    ss << "A2FastModel: weight stream has " << std::distance(it, end) << " trailing bytes";
+    throw std::runtime_error(ss.str());
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Buffer sizing
+// -----------------------------------------------------------------------------
+namespace
+{
+// Smallest power of 2 >= v (v > 0).
+int next_pow2(int v)
+{
+  int p = 1;
+  while (p < v)
+    p <<= 1;
+  return p;
+}
+} // namespace
+
+template <int Channels>
+void A2FastModel<Channels>::SetMaxBufferSize(int maxBufferSize)
+{
+  DSP::SetMaxBufferSize(maxBufferSize);
+
+  _layer_in.assign(static_cast<size_t>(Channels) * maxBufferSize, 0.0f);
+  _head_sum.assign(static_cast<size_t>(Channels) * maxBufferSize, 0.0f);
+  _z.assign(static_cast<size_t>(Channels) * maxBufferSize, 0.0f);
+
+  for (auto& L : _layers)
+  {
+#if NAM_A2_RING_MODE == 1
+    L.pow2_size = next_pow2(L.max_lookback + maxBufferSize);
+    L.pow2_mask = L.pow2_size - 1;
+    L.history.assign(static_cast<size_t>(Channels) * (L.pow2_size + maxBufferSize), 0.0f);
+    L.write_pos = L.max_lookback;
+#else
+    L.history_cols = 2 * L.max_lookback + maxBufferSize;
+    L.history.assign(static_cast<size_t>(Channels) * L.history_cols, 0.0f);
+    L.write_pos = L.max_lookback;
+#endif
+  }
+
+  const int head_lookback = kHeadKernelSize - 1;
+#if NAM_A2_RING_MODE == 1
+  _head_pow2_size = next_pow2(head_lookback + maxBufferSize);
+  _head_pow2_mask = _head_pow2_size - 1;
+  _head_history.assign(static_cast<size_t>(Channels) * (_head_pow2_size + maxBufferSize), 0.0f);
+  _head_write_pos = head_lookback;
+#else
+  _head_history_cols = 2 * head_lookback + maxBufferSize;
+  _head_history.assign(static_cast<size_t>(Channels) * _head_history_cols, 0.0f);
+  _head_write_pos = head_lookback;
+#endif
+}
+
+// -----------------------------------------------------------------------------
+// Ring-write helpers.
+//   Mode 1: pow2 + tail mirror. Constant-time per block (one short memcpy
+//   into the ring, one mirror refresh).
+//   Mode 0: linear with periodic memmove rewind. When write_pos nears the
+//   end of history, memmove the trailing max_lookback cols back to offset 0
+//   and reset write_pos. That memmove is the jitter spike we're measuring.
+// -----------------------------------------------------------------------------
+template <int Channels>
+void A2FastModel<Channels>::_ring_write(Layer& L, int num_frames)
+{
+#if NAM_A2_RING_MODE == 1
+  const int mbs = GetMaxBufferSize();
+  float* const hist = L.history.data();
+  const float* const src = _layer_in.data();
+  const int wp = L.write_pos;
+  const int first = std::min(num_frames, L.pow2_size - wp);
+  std::memcpy(hist + static_cast<size_t>(wp) * Channels, src,
+              static_cast<size_t>(first) * Channels * sizeof(float));
+  if (first < num_frames)
+  {
+    std::memcpy(hist, src + static_cast<size_t>(first) * Channels,
+                static_cast<size_t>(num_frames - first) * Channels * sizeof(float));
+  }
+  std::memcpy(hist + static_cast<size_t>(L.pow2_size) * Channels, hist,
+              static_cast<size_t>(mbs) * Channels * sizeof(float));
+  L.write_pos = (wp + num_frames) & L.pow2_mask;
+#else
+  if (L.write_pos + num_frames > L.history_cols)
+  {
+    const int keep = L.max_lookback;
+    std::memmove(L.history.data(), L.history.data() + static_cast<size_t>(L.write_pos - keep) * Channels,
+                 static_cast<size_t>(keep) * Channels * sizeof(float));
+    L.write_pos = keep;
+  }
+  std::memcpy(L.history.data() + static_cast<size_t>(L.write_pos) * Channels, _layer_in.data(),
+              static_cast<size_t>(num_frames) * Channels * sizeof(float));
+  L.write_pos += num_frames;
+#endif
+}
+
+template <int Channels>
+void A2FastModel<Channels>::_head_ring_write(int num_frames)
+{
+#if NAM_A2_RING_MODE == 1
+  const int mbs = GetMaxBufferSize();
+  float* const hist = _head_history.data();
+  const float* const src = _head_sum.data();
+  const int wp = _head_write_pos;
+  const int first = std::min(num_frames, _head_pow2_size - wp);
+  std::memcpy(hist + static_cast<size_t>(wp) * Channels, src,
+              static_cast<size_t>(first) * Channels * sizeof(float));
+  if (first < num_frames)
+  {
+    std::memcpy(hist, src + static_cast<size_t>(first) * Channels,
+                static_cast<size_t>(num_frames - first) * Channels * sizeof(float));
+  }
+  std::memcpy(hist + static_cast<size_t>(_head_pow2_size) * Channels, hist,
+              static_cast<size_t>(mbs) * Channels * sizeof(float));
+  _head_write_pos = (wp + num_frames) & _head_pow2_mask;
+#else
+  const int keep = kHeadKernelSize - 1;
+  if (_head_write_pos + num_frames > _head_history_cols)
+  {
+    std::memmove(_head_history.data(), _head_history.data() + static_cast<size_t>(_head_write_pos - keep) * Channels,
+                 static_cast<size_t>(keep) * Channels * sizeof(float));
+    _head_write_pos = keep;
+  }
+  std::memcpy(_head_history.data() + static_cast<size_t>(_head_write_pos) * Channels, _head_sum.data(),
+              static_cast<size_t>(num_frames) * Channels * sizeof(float));
+  _head_write_pos += num_frames;
+#endif
+}
+
+// -----------------------------------------------------------------------------
+// Per-layer forward pass. Reads current _layer_in, writes back into _layer_in
+// after applying dilated conv + mixin + LeakyReLU + layer1x1 residual, and
+// accumulates activations into _head_sum.
+// -----------------------------------------------------------------------------
+// Compile-time-specialized per-layer kernel. KernelSize is a template param
+// so the K tap loop + per-tap weight offsets become compile-time constants;
+// clang fully unrolls and can schedule FMAs across taps. Called from the
+// runtime dispatcher below for each A2 kernel size (6 and 15).
+template <int Channels>
+template <int KernelSize>
+void A2FastModel<Channels>::_layer_forward_k(Layer& L, const float* cond, int num_frames)
+{
+  constexpr int K = KernelSize;
+  const int D = L.dilation;
+  // Physical ring position of this block's first frame, offset by `taps_back *
+  // D` samples into the past. In pow2 mode the position is wrapped by mask and
+  // reads spanning the wrap land in the tail mirror; in linear mode write_pos
+  // is monotonic and arithmetic is plain.
+#if NAM_A2_RING_MODE == 1
+  const int mask = L.pow2_mask;
+  auto tap_base_phys = [&](int taps_back) {
+    return (L.write_pos - num_frames - taps_back * D) & mask;
+  };
+#else
+  const int base = L.write_pos - num_frames;
+  auto tap_base_phys = [&](int taps_back) { return base - taps_back * D; };
+#endif
+
+  // Bias is now seeded into z by tap 0 of the ch<=4 path, so fuse_post_conv
+  // skips that add; the Eigen ch>=8 path still folds bias in via colwise +=.
+  auto fuse_post_conv = [&](int f, float* zf) {
+    const float cf = cond[f];
+    for (int b = 0; b < Channels; b++)
+      zf[b] += L.mixin_w[b] * cf;
+    for (int b = 0; b < Channels; b++)
+      zf[b] = (zf[b] >= 0.0f) ? zf[b] : zf[b] * kLeakySlope;
+    float* hsum = &_head_sum[static_cast<size_t>(f) * Channels];
+    for (int b = 0; b < Channels; b++)
+      hsum[b] += zf[b];
+    float* lin = &_layer_in[static_cast<size_t>(f) * Channels];
+    for (int c = 0; c < Channels; c++)
+      lin[c] += L.l1x1_b[c];
+    for (int b = 0; b < Channels; b++)
+    {
+      const float zb = zf[b];
+      const float* wcol = &L.l1x1_w[static_cast<size_t>(b) * Channels];
+      for (int c = 0; c < Channels; c++)
+        lin[c] += wcol[c] * zb;
+    }
+  };
+
+  // Two conv strategies, dispatched at compile time on Channels:
+  //
+  //   - Channels <= 4 (A2 nano): full-block tap-major. The z accumulator lives
+  //     in the heap buffer across all taps, and for each tap the inner f-loop
+  //     iterates over all num_frames. This gives clang frame-level
+  //     parallelism — it vectorizes across 4 frames at a time, which matters
+  //     more than weight-reload cost when the b-loop (3 wide) can't saturate
+  //     NEON lanes on its own.
+  //
+  //   - Channels >= 8 (A2 standard): frame-tiled tap-major with T=4. ztile
+  //     stays in NEON registers across all K taps, amortizing weight loads
+  //     over 4 frames — equivalent to what a GEMM kernel does. Weight reuse
+  //     matters here because the b-loop (8 wide) already saturates SIMD, so
+  //     frame-level parallelism gives no extra headroom. The 1x1 residual is
+  //     also tiled over the same T=4 frames so W1x1 loads are amortized.
+
+  if constexpr (Channels == 3)
+  {
+    // Inner 3x3 GEMV fully unrolled: all 9 weights lifted into named consts
+    // before the frame loop, the c-reduction kept in scalar temps a0/a1/a2 so
+    // the compiler keeps them in FP registers across the frame loop. Mirrors
+    // the nam2c --fused structure.
+    float* z = _z.data();
+
+    // Tap 0: seed z with conv_b (saves the memset-to-zero pass) and fold in
+    // the first tap's FMAs.
+    {
+      const float* wk = &L.conv_w[0];
+      const int tap_base = tap_base_phys(K - 1);
+      const float w0 = wk[0], w1 = wk[1], w2 = wk[2];
+      const float w3 = wk[3], w4 = wk[4], w5 = wk[5];
+      const float w6 = wk[6], w7 = wk[7], w8 = wk[8];
+      const float cb0 = L.conv_b[0], cb1 = L.conv_b[1], cb2 = L.conv_b[2];
+      for (int f = 0; f < num_frames; f++)
+      {
+        const float* src = &L.history[static_cast<size_t>(tap_base + f) * 3];
+        float a0 = cb0 + w0 * src[0];
+        float a1 = cb1 + w1 * src[0];
+        float a2 = cb2 + w2 * src[0];
+        a0 += w3 * src[1];
+        a1 += w4 * src[1];
+        a2 += w5 * src[1];
+        a0 += w6 * src[2];
+        a1 += w7 * src[2];
+        a2 += w8 * src[2];
+        float* zf = z + static_cast<size_t>(f) * 3;
+        zf[0] = a0;
+        zf[1] = a1;
+        zf[2] = a2;
+      }
+    }
+
+    // Taps 1..K-2: accumulate into z with the same unrolled inner kernel.
+    for (int k = 1; k < K - 1; k++)
+    {
+      const float* wk = &L.conv_w[static_cast<size_t>(k) * 9];
+      const int tap_base = tap_base_phys(K - 1 - k);
+      const float w0 = wk[0], w1 = wk[1], w2 = wk[2];
+      const float w3 = wk[3], w4 = wk[4], w5 = wk[5];
+      const float w6 = wk[6], w7 = wk[7], w8 = wk[8];
+      for (int f = 0; f < num_frames; f++)
+      {
+        const float* src = &L.history[static_cast<size_t>(tap_base + f) * 3];
+        float* zf = z + static_cast<size_t>(f) * 3;
+        float a0 = zf[0] + w0 * src[0];
+        float a1 = zf[1] + w1 * src[0];
+        float a2 = zf[2] + w2 * src[0];
+        a0 += w3 * src[1];
+        a1 += w4 * src[1];
+        a2 += w5 * src[1];
+        a0 += w6 * src[2];
+        a1 += w7 * src[2];
+        a2 += w8 * src[2];
+        zf[0] = a0;
+        zf[1] = a1;
+        zf[2] = a2;
+      }
+    }
+
+    // Final tap (K-1, offset 0) fully inlined with the post-conv tail.
+    // Everything runs on register-resident scalars:
+    //   conv tap K-1 -> mixin -> LeakyReLU -> head_sum += -> layer1x1 residual.
+    const float* wk_last = &L.conv_w[static_cast<size_t>(K - 1) * 9];
+    const int tap_base_last = tap_base_phys(0);
+    const float cw0 = wk_last[0], cw1 = wk_last[1], cw2 = wk_last[2];
+    const float cw3 = wk_last[3], cw4 = wk_last[4], cw5 = wk_last[5];
+    const float cw6 = wk_last[6], cw7 = wk_last[7], cw8 = wk_last[8];
+    const float mw0 = L.mixin_w[0], mw1 = L.mixin_w[1], mw2 = L.mixin_w[2];
+    // layer1x1 col-major: lw[b*3 + c] is weight from bottleneck b to output c.
+    const float lw00 = L.l1x1_w[0], lw01 = L.l1x1_w[1], lw02 = L.l1x1_w[2];
+    const float lw10 = L.l1x1_w[3], lw11 = L.l1x1_w[4], lw12 = L.l1x1_w[5];
+    const float lw20 = L.l1x1_w[6], lw21 = L.l1x1_w[7], lw22 = L.l1x1_w[8];
+    const float lb0 = L.l1x1_b[0], lb1 = L.l1x1_b[1], lb2 = L.l1x1_b[2];
+    for (int f = 0; f < num_frames; f++)
+    {
+      const float* src = &L.history[static_cast<size_t>(tap_base_last + f) * 3];
+      const float* zf_mem = z + static_cast<size_t>(f) * 3;
+      // Final tap GEMV.
+      float a0 = zf_mem[0] + cw0 * src[0];
+      float a1 = zf_mem[1] + cw1 * src[0];
+      float a2 = zf_mem[2] + cw2 * src[0];
+      a0 += cw3 * src[1];
+      a1 += cw4 * src[1];
+      a2 += cw5 * src[1];
+      a0 += cw6 * src[2];
+      a1 += cw7 * src[2];
+      a2 += cw8 * src[2];
+      // Mixin + LeakyReLU.
+      const float cf = cond[f];
+      a0 += mw0 * cf;
+      a1 += mw1 * cf;
+      a2 += mw2 * cf;
+      a0 = (a0 >= 0.0f) ? a0 : a0 * kLeakySlope;
+      a1 = (a1 >= 0.0f) ? a1 : a1 * kLeakySlope;
+      a2 = (a2 >= 0.0f) ? a2 : a2 * kLeakySlope;
+      // Head sum accumulate.
+      float* hsum = &_head_sum[static_cast<size_t>(f) * 3];
+      hsum[0] += a0;
+      hsum[1] += a1;
+      hsum[2] += a2;
+      // layer1x1 residual.
+      float* lin = &_layer_in[static_cast<size_t>(f) * 3];
+      lin[0] += lb0 + lw00 * a0 + lw10 * a1 + lw20 * a2;
+      lin[1] += lb1 + lw01 * a0 + lw11 * a1 + lw21 * a2;
+      lin[2] += lb2 + lw02 * a0 + lw12 * a1 + lw22 * a2;
+    }
+  }
+  else
+  {
+    // Use Eigen's tuned 8x8 × 8xN GEMM for the whole block at once. Unlike a
+    // small-tile version, this hits Eigen's actual GEMM kernel (tuned for
+    // inner dimensions of ~64) rather than its tiny-matrix fallback path.
+    //
+    // Compile-time improvements over the generic WaveNet path:
+    //   - Channels and Bottleneck are template constants (no dynamic shape).
+    //   - Per-layer buffers are pre-sized at SetMaxBufferSize; nothing resizes
+    //     during process().
+    //   - No FiLM / gating / head1x1 / grouped-conv branches.
+    //   - No virtual dispatch / conditional on optional layer features.
+    //   - All conv + post-conv ops operate on the full block — even the
+    //     mixin, bias, activation, and 1x1 residual are Eigen block ops so
+    //     they vectorize the same way the GEMMs do.
+    using MatCC = Eigen::Matrix<float, Channels, Channels>;
+    using MatCDyn = Eigen::Matrix<float, Channels, Eigen::Dynamic>;
+    using VecC = Eigen::Matrix<float, Channels, 1>;
+    using RowDyn = Eigen::Matrix<float, 1, Eigen::Dynamic>;
+
+    Eigen::Map<const VecC> conv_b_vec(L.conv_b.data());
+    Eigen::Map<const VecC> mixin_vec(L.mixin_w.data());
+    Eigen::Map<const MatCC> l1x1_mat(L.l1x1_w.data());
+    Eigen::Map<const VecC> l1x1_b_vec(L.l1x1_b.data());
+    Eigen::Map<const RowDyn> cond_row(cond, 1, num_frames);
+
+    Eigen::Map<MatCDyn> ztile(_z.data(), Channels, num_frames);
+    Eigen::Map<MatCDyn> hsum_block(_head_sum.data(), Channels, num_frames);
+    Eigen::Map<MatCDyn> lin_block(_layer_in.data(), Channels, num_frames);
+
+    ztile.setZero();
+
+    // Conv: one 8x8 × 8xN GEMM per tap.
+    for (int k = 0; k < K; k++)
+    {
+      const int tap_base = tap_base_phys(K - 1 - k);
+      Eigen::Map<const MatCC> W(&L.conv_w[static_cast<size_t>(k) * Channels * Channels]);
+      Eigen::Map<const MatCDyn> input_block(&L.history[static_cast<size_t>(tap_base) * Channels], Channels, num_frames);
+      ztile.noalias() += W * input_block;
+    }
+
+    // Post-conv: bias, mixin, LeakyReLU, head_sum, 1x1 residual — all block ops.
+    ztile.colwise() += conv_b_vec;
+    ztile.noalias() += mixin_vec * cond_row;                               // rank-1 outer product
+    ztile = (ztile.array() < 0.0f).select(ztile.array() * kLeakySlope, ztile.array());
+    hsum_block += ztile;
+    lin_block.noalias() += l1x1_mat * ztile;                               // 8x8 × 8xN GEMM
+    lin_block.colwise() += l1x1_b_vec;
+  }
+}
+
+// Runtime dispatcher: selects the K-specialized kernel for this layer.
+// For the A2 shape the detector only admits K in {6, 15}; any other value
+// here means something passed the detector that shouldn't have.
+template <int Channels>
+void A2FastModel<Channels>::_layer_forward(int layer_idx, const float* cond, int num_frames)
+{
+  Layer& L = _layers[layer_idx];
+  _ring_write(L, num_frames);
+  switch (L.kernel_size)
+  {
+    case 6:
+      _layer_forward_k<6>(L, cond, num_frames);
+      break;
+    case 15:
+      _layer_forward_k<15>(L, cond, num_frames);
+      break;
+    default:
+      throw std::runtime_error("A2FastModel: unexpected kernel_size "
+                               + std::to_string(L.kernel_size));
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Head: K=16 dilation-1 conv from Channels to 1, plus bias + scale.
+// -----------------------------------------------------------------------------
+template <int Channels>
+void A2FastModel<Channels>::_head_forward(float* output, int num_frames)
+{
+  _head_ring_write(num_frames);
+#if NAM_A2_RING_MODE == 1
+  const int mask = _head_pow2_mask;
+  auto col_of = [&](int f, int k) {
+    return (_head_write_pos - num_frames + f - (kHeadKernelSize - 1 - k)) & mask;
+  };
+#else
+  const int base = _head_write_pos - num_frames;
+  auto col_of = [&](int f, int k) { return base + f - (kHeadKernelSize - 1 - k); };
+#endif
+
+  for (int f = 0; f < num_frames; f++)
+  {
+    float y = _head_b;
+    for (int k = 0; k < kHeadKernelSize; k++)
+    {
+      const int col = col_of(f, k);
+      const float* src = &_head_history[static_cast<size_t>(col) * Channels];
+      const float* wk = _head_w[k].data();
+      for (int b = 0; b < Channels; b++)
+        y += wk[b] * src[b];
+    }
+    output[f] = y * _head_scale;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// DSP::process override
+// -----------------------------------------------------------------------------
+template <int Channels>
+void A2FastModel<Channels>::process(NAM_SAMPLE** input, NAM_SAMPLE** output, int num_frames)
+{
+  if (num_frames > GetMaxBufferSize())
+    SetMaxBufferSize(num_frames);
+
+  const NAM_SAMPLE* in0 = input[0];
+  NAM_SAMPLE* out0 = output[0];
+
+  // Rechannel: layer_in[c, f] = _rechannel_w[c] * input[f] for c in Channels.
+  // Also prepare float cond buffer (input copied to float for inner loops).
+  std::vector<float> cond(num_frames);
+  for (int f = 0; f < num_frames; f++)
+  {
+    const float x = static_cast<float>(in0[f]);
+    cond[f] = x;
+    float* lin = &_layer_in[static_cast<size_t>(f) * Channels];
+    for (int c = 0; c < Channels; c++)
+      lin[c] = _rechannel_w[c] * x;
+  }
+
+  // Zero head accumulator.
+  std::memset(_head_sum.data(), 0, static_cast<size_t>(num_frames) * Channels * sizeof(float));
+
+  for (int li = 0; li < kNumLayers; li++)
+    _layer_forward(li, cond.data(), num_frames);
+
+  // Output.
+  std::vector<float> head_out(num_frames);
+  _head_forward(head_out.data(), num_frames);
+  for (int f = 0; f < num_frames; f++)
+    out0[f] = static_cast<NAM_SAMPLE>(head_out[f]);
+}
+
+// -----------------------------------------------------------------------------
+// A2FastConfig — wraps the constructed DSP behind the ModelConfig interface.
+// -----------------------------------------------------------------------------
+struct A2FastConfig : public ModelConfig
+{
+  int channels = 0;
+
+  std::unique_ptr<DSP> create(std::vector<float> weights, double sampleRate) override
+  {
+    if (channels == 3)
+      return std::make_unique<A2FastModel<3>>(std::move(weights), sampleRate);
+    if (channels == 8)
+      return std::make_unique<A2FastModel<8>>(std::move(weights), sampleRate);
+    throw std::runtime_error("A2FastConfig: unsupported channel count " + std::to_string(channels));
+  }
+};
+
+// -----------------------------------------------------------------------------
+// Detector helpers
+// -----------------------------------------------------------------------------
+bool close_to(float v, float target)
+{
+  return std::fabs(v - target) <= 1e-7f;
+}
+
+bool all_none_strings(const nlohmann::json& j)
+{
+  if (!j.is_array())
+    return false;
+  for (const auto& e : j)
+  {
+    if (!e.is_string() || e.get<std::string>() != "none")
+      return false;
+  }
+  return true;
+}
+
+bool all_null(const nlohmann::json& j)
+{
+  if (!j.is_array())
+    return false;
+  for (const auto& e : j)
+  {
+    if (!e.is_null())
+      return false;
+  }
+  return true;
+}
+
+bool film_inactive(const nlohmann::json& layer, const char* key)
+{
+  auto it = layer.find(key);
+  if (it == layer.end() || it->is_null())
+    return true;
+  if (it->is_boolean())
+    return !it->get<bool>();
+  if (it->is_object())
+    return !it->value("active", false);
+  return false;
+}
+
+} // namespace
+
+// -----------------------------------------------------------------------------
+// Public API
+// -----------------------------------------------------------------------------
+bool is_a2_shape(const nlohmann::json& config, int* channels)
+{
+  // Exactly one layer array
+  auto layers_it = config.find("layers");
+  if (layers_it == config.end() || !layers_it->is_array() || layers_it->size() != 1)
+    return false;
+
+  // No post-stack head
+  auto head_it = config.find("head");
+  if (head_it != config.end() && !head_it->is_null())
+    return false;
+
+  // head_scale must be exactly 0.01
+  auto hs_it = config.find("head_scale");
+  if (hs_it == config.end() || !hs_it->is_number())
+    return false;
+  if (!close_to(hs_it->get<float>(), kHeadScale))
+    return false;
+
+  // in_channels defaults to 1, must be 1
+  if (config.value("in_channels", 1) != 1)
+    return false;
+
+  const auto& la = (*layers_it)[0];
+
+  if (la.value("input_size", 0) != 1)
+    return false;
+  if (la.value("condition_size", 0) != 1)
+    return false;
+
+  const int ch = la.value("channels", 0);
+  const int bn = la.value("bottleneck", 0);
+  if (ch != bn)
+    return false;
+  if (ch != 3 && ch != 8)
+    return false;
+
+  // kernel_sizes must match kKernelSizes exactly
+  auto ks_it = la.find("kernel_sizes");
+  if (ks_it == la.end() || !ks_it->is_array() || ks_it->size() != kNumLayers)
+    return false;
+  for (int i = 0; i < kNumLayers; i++)
+  {
+    if (!(*ks_it)[i].is_number_integer() || (*ks_it)[i].get<int>() != kKernelSizes[i])
+      return false;
+  }
+
+  // dilations must match kDilations exactly
+  auto dl_it = la.find("dilations");
+  if (dl_it == la.end() || !dl_it->is_array() || dl_it->size() != kNumLayers)
+    return false;
+  for (int i = 0; i < kNumLayers; i++)
+  {
+    if (!(*dl_it)[i].is_number_integer() || (*dl_it)[i].get<int>() != kDilations[i])
+      return false;
+  }
+
+  // activation: all LeakyReLU(0.01)
+  auto act_it = la.find("activation");
+  if (act_it == la.end() || !act_it->is_array() || act_it->size() != kNumLayers)
+    return false;
+  for (const auto& a : *act_it)
+  {
+    if (!a.is_object() || a.value("type", std::string()) != "LeakyReLU")
+      return false;
+    if (!close_to(a.value("negative_slope", 0.0f), kLeakySlope))
+      return false;
+  }
+
+  // gating_mode: all "none" (or field absent)
+  auto gm_it = la.find("gating_mode");
+  if (gm_it != la.end() && !gm_it->is_null())
+  {
+    if (!all_none_strings(*gm_it) || gm_it->size() != kNumLayers)
+      return false;
+  }
+
+  // secondary_activation: all null (or field absent)
+  auto sa_it = la.find("secondary_activation");
+  if (sa_it != la.end() && !sa_it->is_null())
+  {
+    if (!all_null(*sa_it) || sa_it->size() != kNumLayers)
+      return false;
+  }
+
+  // head1x1 inactive
+  auto h1x1_it = la.find("head1x1");
+  if (h1x1_it != la.end() && h1x1_it->is_object() && h1x1_it->value("active", false))
+    return false;
+
+  // layer1x1 active with groups=1
+  auto l1x1_it = la.find("layer1x1");
+  if (l1x1_it == la.end() || !l1x1_it->is_object())
+    return false;
+  if (!l1x1_it->value("active", false))
+    return false;
+  if (l1x1_it->value("groups", 1) != 1)
+    return false;
+
+  // Layer-array head rechannel: k=16, out_channels=1, bias=true
+  auto lah_it = la.find("head");
+  if (lah_it == la.end() || !lah_it->is_object())
+    return false;
+  if (lah_it->value("out_channels", 0) != 1)
+    return false;
+  if (lah_it->value("kernel_size", 0) != kHeadKernelSize)
+    return false;
+  if (!lah_it->value("bias", false))
+    return false;
+
+  // No FiLM anywhere
+  for (const char* key :
+       {"conv_pre_film", "conv_post_film", "input_mixin_pre_film", "input_mixin_post_film", "activation_pre_film",
+        "activation_post_film", "layer1x1_post_film", "head1x1_post_film"})
+  {
+    if (!film_inactive(la, key))
+      return false;
+  }
+
+  // No grouped convolutions
+  if (la.value("groups_input", 1) != 1)
+    return false;
+  if (la.value("groups_input_mixin", 1) != 1)
+    return false;
+
+  // Not slimmable
+  auto slim_it = la.find("slimmable");
+  if (slim_it != la.end() && !slim_it->is_null())
+    return false;
+
+  if (channels)
+    *channels = ch;
+  return true;
+}
+
+std::unique_ptr<ModelConfig> create_a2_fast_config(const nlohmann::json& config, double sampleRate)
+{
+  (void)sampleRate;
+  int ch = 0;
+  if (!is_a2_shape(config, &ch))
+    throw std::runtime_error("create_a2_fast_config: config does not match A2 shape");
+  auto out = std::make_unique<A2FastConfig>();
+  out->channels = ch;
+  return out;
+}
+
+} // namespace a2_fast
+} // namespace wavenet
+} // namespace nam
+
+#endif // NAM_ENABLE_A2_FAST

--- a/NAM/wavenet/a2_fast.cpp
+++ b/NAM/wavenet/a2_fast.cpp
@@ -13,11 +13,14 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <cstring>
+#include <iterator>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <Eigen/Dense>
@@ -424,29 +427,6 @@ void A2FastModel<Channels>::_layer_forward_k(Layer& L, const float* cond, int nu
   const int base = L.write_pos - num_frames;
   auto tap_base_phys = [&](int taps_back) { return base - taps_back * D; };
 #endif
-
-  // Bias is now seeded into z by tap 0 of the ch<=4 path, so fuse_post_conv
-  // skips that add; the Eigen ch>=8 path still folds bias in via colwise +=.
-  auto fuse_post_conv = [&](int f, float* zf) {
-    const float cf = cond[f];
-    for (int b = 0; b < Channels; b++)
-      zf[b] += L.mixin_w[b] * cf;
-    for (int b = 0; b < Channels; b++)
-      zf[b] = (zf[b] >= 0.0f) ? zf[b] : zf[b] * kLeakySlope;
-    float* hsum = &_head_sum[static_cast<size_t>(f) * Channels];
-    for (int b = 0; b < Channels; b++)
-      hsum[b] += zf[b];
-    float* lin = &_layer_in[static_cast<size_t>(f) * Channels];
-    for (int c = 0; c < Channels; c++)
-      lin[c] += L.l1x1_b[c];
-    for (int b = 0; b < Channels; b++)
-    {
-      const float zb = zf[b];
-      const float* wcol = &L.l1x1_w[static_cast<size_t>(b) * Channels];
-      for (int c = 0; c < Channels; c++)
-        lin[c] += wcol[c] * zb;
-    }
-  };
 
   // Two conv strategies, dispatched at compile time on Channels:
   //

--- a/NAM/wavenet/a2_fast.h
+++ b/NAM/wavenet/a2_fast.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// Specialized WaveNet fast path for the A2 standard (Channels=8) and
+// A2 nano (Channels=3) models. Shares the same architecture shape; only
+// the channel count differs.
+//
+// When NAM_ENABLE_A2_FAST is defined at build time, wavenet::create_config
+// consults is_a2_shape() on every incoming WaveNet config and, on match,
+// instantiates an A2FastModel<Channels> instead of the generic WaveNet.
+//
+// The baseline here is correct-but-unoptimized (plain column-major loops).
+// Follow-up optimizations (unrolled GEMV, tap-major nest, factored
+// per-kernel-size helpers) plug into the same class.
+
+#if defined(NAM_ENABLE_A2_FAST)
+
+#include <array>
+#include <memory>
+
+#include "../model_config.h"
+#include "json.hpp"
+
+namespace nam
+{
+namespace wavenet
+{
+namespace a2_fast
+{
+
+/// \brief Number of layers in an A2 layer array.
+constexpr int kNumLayers = 23;
+/// \brief Kernel size of the layer-array head rechannel convolution.
+constexpr int kHeadKernelSize = 16;
+/// \brief Head scale factor used by every A2 model.
+constexpr float kHeadScale = 0.01f;
+/// \brief LeakyReLU negative-slope used by every layer.
+constexpr float kLeakySlope = 0.01f;
+
+/// \brief Per-layer kernel sizes (fixed pattern shared by A2 standard + nano).
+inline constexpr std::array<int, kNumLayers> kKernelSizes = {
+  6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 15, 15, 6, 6, 6, 6, 6, 6, 6};
+
+/// \brief Per-layer dilations (fixed pattern shared by A2 standard + nano).
+inline constexpr std::array<int, kNumLayers> kDilations = {
+  1, 3, 7, 17, 41, 101, 239, 1, 3, 7, 17, 41, 101, 239, 1, 13, 1, 3, 7, 17, 41, 101, 239};
+
+/// \brief Strict detector: returns true iff config matches the A2 shape.
+/// \param config   The "config" sub-object from a .nam WaveNet entry.
+/// \param channels Out-param set to 3 (A2 nano) or 8 (A2 standard) on match.
+/// \return true if every architectural knob matches the A2 signature exactly.
+bool is_a2_shape(const nlohmann::json& config, int* channels);
+
+/// \brief Build a ModelConfig that instantiates the A2 fast path.
+/// \pre is_a2_shape(config, ...) returned true.
+std::unique_ptr<ModelConfig> create_a2_fast_config(const nlohmann::json& config, double sampleRate);
+
+} // namespace a2_fast
+} // namespace wavenet
+} // namespace nam
+
+#endif // NAM_ENABLE_A2_FAST

--- a/NAM/wavenet/model.cpp
+++ b/NAM/wavenet/model.cpp
@@ -12,6 +12,10 @@
 #include "slimmable.h"
 #include "model.h"
 
+#if defined(NAM_ENABLE_A2_FAST)
+#include "a2_fast.h"
+#endif
+
 // detail::Head (WaveNet post-stack head) =====================================
 
 nam::wavenet::detail::Head::Head(const HeadParams& params)
@@ -1217,6 +1221,11 @@ std::unique_ptr<nam::ModelConfig> nam::wavenet::create_config(const nlohmann::js
 {
   if (config_is_slimmable_wavenet(config))
     return nam::slimmable_wavenet::create_config(config, sampleRate);
+
+#if defined(NAM_ENABLE_A2_FAST)
+  if (int a2_channels = 0; nam::wavenet::a2_fast::is_a2_shape(config, &a2_channels))
+    return nam::wavenet::a2_fast::create_a2_fast_config(config, sampleRate);
+#endif
 
   auto wc = std::make_unique<WaveNetConfig>();
   auto parsed = parse_config_json(config, sampleRate);

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -43,6 +43,25 @@ else()
 	)
 endif()
 add_executable(benchmodel_bufsize benchmodel_bufsize.cpp ${NAM_SOURCES})
+add_executable(bench_a2_fast bench_a2_fast.cpp ${NAM_SOURCES})
+target_compile_features(bench_a2_fast PUBLIC cxx_std_20)
+set_target_properties(bench_a2_fast PROPERTIES
+	CXX_VISIBILITY_PRESET hidden
+	INTERPROCEDURAL_OPTIMIZATION TRUE
+	PREFIX ""
+)
+if (MSVC)
+	target_compile_options(bench_a2_fast PRIVATE
+		"$<$<CONFIG:DEBUG>:/W4>"
+		"$<$<CONFIG:RELEASE>:/O2>"
+	)
+else()
+	target_compile_options(bench_a2_fast PRIVATE
+		-Wall -Wextra -Wpedantic -Wstrict-aliasing -Wunreachable-code -Wno-unused-parameter
+		"$<$<CONFIG:DEBUG>:-Og;-ggdb;-Werror>"
+		"$<$<CONFIG:RELEASE>:-Ofast>"
+	)
+endif()
 add_executable(run_tests run_tests.cpp test/allocation_tracking.cpp ${NAM_SOURCES})
 # Compile run_tests without optimizations to ensure allocation tracking works correctly
 # Also ensure assertions are enabled (NDEBUG is not defined) so tests actually run

--- a/tools/bench_a2_fast.cpp
+++ b/tools/bench_a2_fast.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -23,6 +24,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "json.hpp"

--- a/tools/bench_a2_fast.cpp
+++ b/tools/bench_a2_fast.cpp
@@ -1,0 +1,268 @@
+// Side-by-side benchmark for the A2 fast-path WaveNet vs the generic WaveNet.
+//
+// Loads a .nam file once, constructs two DSPs from the same config + weights:
+//   - fast: via a2_fast::create_a2_fast_config (explicit A2 factory)
+//   - generic: via wavenet::parse_config_json (bypassing the dispatcher's A2 shortcut)
+// Runs both over the same audio, reports median wall time + real-time factor.
+//
+// Usage:
+//   bench_a2_fast [--buffer N] [--seconds S] [--iters I] <model.nam> [<model.nam> ...]
+//
+// Only compiled when NAM_ENABLE_A2_FAST is defined.
+
+#if defined(NAM_ENABLE_A2_FAST)
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "json.hpp"
+
+#include "NAM/dsp.h"
+#include "NAM/wavenet/a2_fast.h"
+#include "NAM/wavenet/model.h"
+
+using clock_t_hr = std::chrono::high_resolution_clock;
+using ns = std::chrono::nanoseconds;
+
+namespace
+{
+
+struct Options
+{
+  int buffer_size = 64;
+  double seconds = 2.0;
+  int iterations = 10;
+  std::vector<std::string> model_paths;
+};
+
+Options parse_args(int argc, char** argv)
+{
+  Options o;
+  for (int i = 1; i < argc; i++)
+  {
+    std::string a = argv[i];
+    if (a == "--buffer" && i + 1 < argc)
+      o.buffer_size = std::atoi(argv[++i]);
+    else if (a == "--seconds" && i + 1 < argc)
+      o.seconds = std::atof(argv[++i]);
+    else if (a == "--iters" && i + 1 < argc)
+      o.iterations = std::atoi(argv[++i]);
+    else if (a == "-h" || a == "--help")
+    {
+      std::cerr << "Usage: bench_a2_fast [--buffer N] [--seconds S] [--iters I] <model.nam> ...\n";
+      std::exit(0);
+    }
+    else
+      o.model_paths.push_back(std::move(a));
+  }
+  return o;
+}
+
+struct LoadedModel
+{
+  nlohmann::json config;
+  std::vector<float> weights;
+  double sample_rate = 48000.0;
+  std::string path;
+};
+
+LoadedModel load_nam(const std::string& path)
+{
+  LoadedModel m;
+  m.path = path;
+  std::ifstream is(path);
+  if (!is)
+    throw std::runtime_error("Could not open " + path);
+  nlohmann::json j;
+  is >> j;
+  if (j.value("architecture", std::string()) != "WaveNet")
+    throw std::runtime_error(path + ": not a WaveNet model");
+  m.config = j["config"];
+  m.weights = j["weights"].get<std::vector<float>>();
+  if (j.contains("sample_rate") && !j["sample_rate"].is_null())
+    m.sample_rate = j["sample_rate"].get<double>();
+  return m;
+}
+
+struct Stats
+{
+  double min;
+  double p50;
+  double p99;
+  double p999;
+  double max;
+  double mean;
+  size_t n;
+};
+
+double percentile(const std::vector<double>& sorted_xs, double pct)
+{
+  if (sorted_xs.empty())
+    return 0.0;
+  const double idx = pct * (sorted_xs.size() - 1);
+  const size_t i = static_cast<size_t>(idx);
+  const double frac = idx - i;
+  if (i + 1 >= sorted_xs.size())
+    return sorted_xs[i];
+  return sorted_xs[i] * (1.0 - frac) + sorted_xs[i + 1] * frac;
+}
+
+Stats compute_stats(std::vector<double> xs)
+{
+  Stats s{};
+  if (xs.empty())
+    return s;
+  std::sort(xs.begin(), xs.end());
+  double sum = 0.0;
+  for (double x : xs)
+    sum += x;
+  s.n = xs.size();
+  s.min = xs.front();
+  s.max = xs.back();
+  s.mean = sum / xs.size();
+  s.p50 = percentile(xs, 0.50);
+  s.p99 = percentile(xs, 0.99);
+  s.p999 = percentile(xs, 0.999);
+  return s;
+}
+
+// Run one full iteration, timing each block separately. Returns per-block times
+// in milliseconds, appended to `out_times`.
+void time_iteration_per_block(nam::DSP& dsp, std::vector<double>& input, std::vector<double>& output, int total,
+                              int buffer_size, std::vector<double>& out_times)
+{
+  const double* in_base = input.data();
+  double* out_base = output.data();
+  int pos = 0;
+  while (pos < total)
+  {
+    const int n = std::min(buffer_size, total - pos);
+    const double* in_ptr = in_base + pos;
+    double* out_ptr = out_base + pos;
+    const double* in_arr[] = {in_ptr};
+    double* out_arr[] = {out_ptr};
+    auto t0 = clock_t_hr::now();
+    dsp.process(const_cast<double**>(in_arr), out_arr, n);
+    auto t1 = clock_t_hr::now();
+    out_times.push_back(std::chrono::duration<double, std::milli>(t1 - t0).count());
+    pos += n;
+  }
+}
+
+void bench_model(const LoadedModel& m, const Options& o)
+{
+  int channels = 0;
+  if (!nam::wavenet::a2_fast::is_a2_shape(m.config, &channels))
+  {
+    std::cerr << "[skip] " << m.path << ": not an A2-shaped WaveNet\n";
+    return;
+  }
+
+  // Build fast path.
+  auto fast_cfg = nam::wavenet::a2_fast::create_a2_fast_config(m.config, m.sample_rate);
+  std::vector<float> w_fast = m.weights;
+  auto fast_dsp = fast_cfg->create(std::move(w_fast), m.sample_rate);
+
+  // Build generic path (bypass dispatcher).
+  auto generic_cfg = nam::wavenet::parse_config_json(m.config, m.sample_rate);
+  std::vector<float> w_gen = m.weights;
+  auto generic_dsp = generic_cfg.create(std::move(w_gen), m.sample_rate);
+
+  const int total = static_cast<int>(o.seconds * m.sample_rate);
+  std::vector<double> input(total);
+  std::vector<double> output(total, 0.0);
+  for (int i = 0; i < total; i++)
+  {
+    const double t = static_cast<double>(i) / m.sample_rate;
+    input[i] = 0.25 * std::sin(2.0 * M_PI * 220.0 * t) + 0.10 * std::sin(2.0 * M_PI * 1230.0 * t);
+  }
+
+  fast_dsp->Reset(m.sample_rate, o.buffer_size);
+  generic_dsp->Reset(m.sample_rate, o.buffer_size);
+
+  // Warm up caches with one untimed iteration each.
+  {
+    std::vector<double> discard;
+    time_iteration_per_block(*fast_dsp, input, output, total, o.buffer_size, discard);
+    discard.clear();
+    time_iteration_per_block(*generic_dsp, input, output, total, o.buffer_size, discard);
+  }
+
+  std::vector<double> fast_block_times;
+  std::vector<double> gen_block_times;
+  const int blocks_per_iter = (total + o.buffer_size - 1) / o.buffer_size;
+  fast_block_times.reserve(o.iterations * blocks_per_iter);
+  gen_block_times.reserve(o.iterations * blocks_per_iter);
+  for (int it = 0; it < o.iterations; it++)
+  {
+    time_iteration_per_block(*fast_dsp, input, output, total, o.buffer_size, fast_block_times);
+    time_iteration_per_block(*generic_dsp, input, output, total, o.buffer_size, gen_block_times);
+  }
+
+  const Stats fast_s = compute_stats(fast_block_times);
+  const Stats gen_s = compute_stats(gen_block_times);
+  const double block_audio_us = 1e6 * o.buffer_size / m.sample_rate;
+
+  const std::string arch = (channels == 3) ? "A2 nano" : (channels == 8 ? "A2 standard" : "A2 unknown");
+
+  auto fmt_us = [](double ms) { return ms * 1000.0; };
+  std::cout << "\n== " << m.path << "  (" << arch << ", Channels=" << channels << ") ==\n";
+  std::cout << "   audio=" << std::fixed << std::setprecision(0) << (1000.0 * total / m.sample_rate) << "ms @ "
+            << static_cast<int>(m.sample_rate) << "Hz, block=" << o.buffer_size << ", iters=" << o.iterations
+            << " (" << fast_s.n << " blocks timed each)\n";
+  std::cout << "   per-block audio deadline: " << std::fixed << std::setprecision(1) << block_audio_us << " us\n";
+  std::cout << std::fixed << std::setprecision(2);
+  std::cout << "                  min     p50     p99     p99.9   max    mean\n";
+  std::cout << "   fast    (us): " << std::setw(7) << fmt_us(fast_s.min) << " " << std::setw(7) << fmt_us(fast_s.p50)
+            << " " << std::setw(7) << fmt_us(fast_s.p99) << " " << std::setw(7) << fmt_us(fast_s.p999) << " "
+            << std::setw(7) << fmt_us(fast_s.max) << " " << std::setw(7) << fmt_us(fast_s.mean) << "\n";
+  std::cout << "   generic (us): " << std::setw(7) << fmt_us(gen_s.min) << " " << std::setw(7) << fmt_us(gen_s.p50)
+            << " " << std::setw(7) << fmt_us(gen_s.p99) << " " << std::setw(7) << fmt_us(gen_s.p999) << " "
+            << std::setw(7) << fmt_us(gen_s.max) << " " << std::setw(7) << fmt_us(gen_s.mean) << "\n";
+  const double fast_rtf = (block_audio_us / 1000.0) / fast_s.p50;
+  const double gen_rtf = (block_audio_us / 1000.0) / gen_s.p50;
+  const double speedup = gen_s.p50 / fast_s.p50;
+  std::cout << "   RTF (p50):  fast=" << fast_rtf << "x  generic=" << gen_rtf << "x  speedup=" << speedup << "x\n";
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+  Options o = parse_args(argc, argv);
+  if (o.model_paths.empty())
+  {
+    std::cerr << "Usage: bench_a2_fast [--buffer N] [--seconds S] [--iters I] <model.nam> ...\n";
+    return 1;
+  }
+  for (const auto& p : o.model_paths)
+  {
+    try
+    {
+      bench_model(load_nam(p), o);
+    }
+    catch (const std::exception& e)
+    {
+      std::cerr << "[error] " << p << ": " << e.what() << "\n";
+    }
+  }
+  return 0;
+}
+
+#else
+int main()
+{
+  std::cerr << "bench_a2_fast: rebuild with NAM_ENABLE_A2_FAST=ON.\n";
+  return 1;
+}
+#endif

--- a/tools/run_tests.cpp
+++ b/tools/run_tests.cpp
@@ -321,6 +321,8 @@ int main()
   test_a2_fast::test_detector_rejects_gating();
   test_a2_fast::test_matches_generic_nano();
   test_a2_fast::test_matches_generic_standard();
+  test_a2_fast::test_process_realtime_safe_nano();
+  test_a2_fast::test_process_realtime_safe_standard();
 #endif
 
   std::cout << "Success!" << std::endl;

--- a/tools/run_tests.cpp
+++ b/tools/run_tests.cpp
@@ -33,6 +33,7 @@
 #include "test/test_container.cpp"
 #include "test/test_render_slim.cpp"
 #include "test/test_slimmable_wavenet.cpp"
+#include "test/test_a2_fast.cpp"
 
 int main()
 {
@@ -309,6 +310,18 @@ int main()
   test_slimmable_wavenet::test_wavenet_without_slimmable_loads_as_regular();
   test_slimmable_wavenet::test_unsupported_method_throws();
   test_slimmable_wavenet::test_slimmed_matches_small_model();
+
+#if defined(NAM_ENABLE_A2_FAST)
+  // A2 fast-path WaveNet: detector coverage + numerical match against generic.
+  test_a2_fast::test_detector_matches_nano();
+  test_a2_fast::test_detector_matches_standard();
+  test_a2_fast::test_detector_rejects_wrong_channels();
+  test_a2_fast::test_detector_rejects_wrong_kernel_sizes();
+  test_a2_fast::test_detector_rejects_wrong_activation();
+  test_a2_fast::test_detector_rejects_gating();
+  test_a2_fast::test_matches_generic_nano();
+  test_a2_fast::test_matches_generic_standard();
+#endif
 
   std::cout << "Success!" << std::endl;
 #ifdef ADDASSERT

--- a/tools/test/test_a2_fast.cpp
+++ b/tools/test/test_a2_fast.cpp
@@ -1,0 +1,259 @@
+// Numerical verification for the A2 fast-path WaveNet:
+// for a config that matches the A2 shape, the fast path must produce the same
+// output as the generic WaveNet on the same input and weights.
+//
+// Built only when NAM_ENABLE_A2_FAST is defined at compile time.
+
+#if defined(NAM_ENABLE_A2_FAST)
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "json.hpp"
+
+#include "NAM/dsp.h"
+#include "NAM/wavenet/a2_fast.h"
+#include "NAM/wavenet/model.h"
+
+namespace test_a2_fast
+{
+namespace
+{
+
+// Build a JSON config with the A2 shape, parameterized by channel count
+// (3 = A2 nano, 8 = A2 standard). Follows the real .nam schema so both the
+// strict detector and the generic parser accept it.
+nlohmann::json build_a2_config(int channels)
+{
+  using nlohmann::json;
+
+  json activation = json::array();
+  json gating_mode = json::array();
+  json secondary = json::array();
+  for (int i = 0; i < nam::wavenet::a2_fast::kNumLayers; i++)
+  {
+    activation.push_back({{"type", "LeakyReLU"}, {"negative_slope", nam::wavenet::a2_fast::kLeakySlope}});
+    gating_mode.push_back("none");
+    secondary.push_back(nullptr);
+  }
+
+  json kernel_sizes = json::array();
+  json dilations = json::array();
+  for (int i = 0; i < nam::wavenet::a2_fast::kNumLayers; i++)
+  {
+    kernel_sizes.push_back(nam::wavenet::a2_fast::kKernelSizes[i]);
+    dilations.push_back(nam::wavenet::a2_fast::kDilations[i]);
+  }
+
+  json film_inactive = {{"active", false}, {"shift", true}, {"groups", 1}};
+
+  json layer;
+  layer["input_size"] = 1;
+  layer["condition_size"] = 1;
+  layer["channels"] = channels;
+  layer["bottleneck"] = channels;
+  layer["kernel_sizes"] = kernel_sizes;
+  layer["dilations"] = dilations;
+  layer["activation"] = activation;
+  layer["gating_mode"] = gating_mode;
+  layer["secondary_activation"] = secondary;
+  layer["head"] = {{"out_channels", 1}, {"kernel_size", nam::wavenet::a2_fast::kHeadKernelSize}, {"bias", true}};
+  layer["head1x1"] = {{"active", false}, {"out_channels", 1}, {"groups", 1}};
+  layer["layer1x1"] = {{"active", true}, {"groups", 1}};
+  layer["conv_pre_film"] = film_inactive;
+  layer["conv_post_film"] = film_inactive;
+  layer["input_mixin_pre_film"] = film_inactive;
+  layer["input_mixin_post_film"] = film_inactive;
+  layer["activation_pre_film"] = film_inactive;
+  layer["activation_post_film"] = film_inactive;
+  layer["layer1x1_post_film"] = film_inactive;
+  layer["head1x1_post_film"] = film_inactive;
+  layer["groups_input"] = 1;
+  layer["groups_input_mixin"] = 1;
+
+  json config;
+  config["layers"] = json::array({layer});
+  config["head_scale"] = nam::wavenet::a2_fast::kHeadScale;
+  return config;
+}
+
+// Weight count for the A2 layer array with the given channel count.
+// Must match the order and sizes expected by both the generic WaveNet parser
+// and A2FastModel::_load_weights.
+int a2_weight_count(int channels)
+{
+  const int bn = channels;
+  int total = /*rechannel*/ channels;
+  for (int i = 0; i < nam::wavenet::a2_fast::kNumLayers; i++)
+  {
+    const int K = nam::wavenet::a2_fast::kKernelSizes[i];
+    total += bn * channels * K + bn; // conv1d weights + bias
+    total += bn;                     // input mixin (no bias)
+    total += channels * bn + channels; // layer1x1 + bias
+  }
+  total += channels * nam::wavenet::a2_fast::kHeadKernelSize + 1; // head rechannel + bias
+  total += 1; // trailing head_scale (read by WaveNet::set_weights_)
+  return total;
+}
+
+std::vector<float> make_deterministic_weights(int count, uint32_t seed)
+{
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<float> dist(-0.3f, 0.3f);
+  std::vector<float> w(count);
+  for (auto& x : w)
+    x = dist(rng);
+  return w;
+}
+
+std::vector<NAM_SAMPLE> make_test_input(int num_frames, double sample_rate)
+{
+  std::vector<NAM_SAMPLE> in(num_frames);
+  // Two-tone signal so the network sees varied content.
+  for (int i = 0; i < num_frames; i++)
+  {
+    const double t = static_cast<double>(i) / sample_rate;
+    in[i] = static_cast<NAM_SAMPLE>(0.25 * std::sin(2.0 * M_PI * 220.0 * t)
+                                    + 0.10 * std::sin(2.0 * M_PI * 1230.0 * t));
+  }
+  return in;
+}
+
+std::vector<NAM_SAMPLE> run_dsp(nam::DSP& dsp, const std::vector<NAM_SAMPLE>& input, int block_size)
+{
+  // Reset also prewarms.
+  dsp.Reset(48000.0, block_size);
+  std::vector<NAM_SAMPLE> out(input.size(), static_cast<NAM_SAMPLE>(0));
+  int pos = 0;
+  const int total = static_cast<int>(input.size());
+  while (pos < total)
+  {
+    const int n = std::min(block_size, total - pos);
+    const NAM_SAMPLE* in_ptr = input.data() + pos;
+    NAM_SAMPLE* out_ptr = out.data() + pos;
+    const NAM_SAMPLE* in_arr[] = {in_ptr};
+    NAM_SAMPLE* out_arr[] = {out_ptr};
+    dsp.process(const_cast<NAM_SAMPLE**>(in_arr), out_arr, n);
+    pos += n;
+  }
+  return out;
+}
+
+void compare(const std::vector<NAM_SAMPLE>& a, const std::vector<NAM_SAMPLE>& b, int channels, int block_size,
+             double tol)
+{
+  assert(a.size() == b.size());
+  double max_diff = 0.0;
+  int max_i = 0;
+  for (size_t i = 0; i < a.size(); i++)
+  {
+    const double d = std::fabs(static_cast<double>(a[i]) - static_cast<double>(b[i]));
+    if (d > max_diff)
+    {
+      max_diff = d;
+      max_i = static_cast<int>(i);
+    }
+  }
+  if (!(max_diff < tol))
+  {
+    std::cerr << "A2FastModel<" << channels << "> diverges from generic WaveNet "
+              << "(block=" << block_size << "): max |diff| = " << max_diff << " at i=" << max_i
+              << " (generic=" << a[max_i] << ", fast=" << b[max_i] << ")" << std::endl;
+    assert(false);
+  }
+}
+
+} // namespace
+
+void test_detector_matches_nano()
+{
+  auto cfg = build_a2_config(3);
+  int ch = 0;
+  assert(nam::wavenet::a2_fast::is_a2_shape(cfg, &ch));
+  assert(ch == 3);
+}
+
+void test_detector_matches_standard()
+{
+  auto cfg = build_a2_config(8);
+  int ch = 0;
+  assert(nam::wavenet::a2_fast::is_a2_shape(cfg, &ch));
+  assert(ch == 8);
+}
+
+void test_detector_rejects_wrong_channels()
+{
+  auto cfg = build_a2_config(3);
+  cfg["layers"][0]["channels"] = 4;
+  cfg["layers"][0]["bottleneck"] = 4;
+  assert(!nam::wavenet::a2_fast::is_a2_shape(cfg, nullptr));
+}
+
+void test_detector_rejects_wrong_kernel_sizes()
+{
+  auto cfg = build_a2_config(8);
+  cfg["layers"][0]["kernel_sizes"][0] = 7; // tweak first entry
+  assert(!nam::wavenet::a2_fast::is_a2_shape(cfg, nullptr));
+}
+
+void test_detector_rejects_wrong_activation()
+{
+  auto cfg = build_a2_config(8);
+  cfg["layers"][0]["activation"][0] = {{"type", "Tanh"}};
+  assert(!nam::wavenet::a2_fast::is_a2_shape(cfg, nullptr));
+}
+
+void test_detector_rejects_gating()
+{
+  auto cfg = build_a2_config(3);
+  cfg["layers"][0]["gating_mode"][0] = "gated";
+  assert(!nam::wavenet::a2_fast::is_a2_shape(cfg, nullptr));
+}
+
+void test_matches_generic(int channels)
+{
+  const auto cfg = build_a2_config(channels);
+  const int weight_count = a2_weight_count(channels);
+  const auto weights = make_deterministic_weights(weight_count, /*seed=*/0xA2FA500u + channels);
+
+  // Fast path: build through the explicit A2 factory.
+  auto fast_cfg = nam::wavenet::a2_fast::create_a2_fast_config(cfg, 48000.0);
+  std::vector<float> w_fast = weights;
+  auto fast_dsp = fast_cfg->create(std::move(w_fast), 48000.0);
+
+  // Generic path: call parse_config_json directly so the dispatcher's A2 shortcut
+  // doesn't kick in. This gives us the reference WaveNet against the same config.
+  auto generic_cfg = nam::wavenet::parse_config_json(cfg, 48000.0);
+  std::vector<float> w_gen = weights;
+  auto generic_dsp = generic_cfg.create(std::move(w_gen), 48000.0);
+
+  // Exercise with two block sizes to catch any off-by-one in the ring-buffer rewind.
+  const int total = 2048;
+  const auto input = make_test_input(total, 48000.0);
+  for (int block : {64, 256})
+  {
+    const auto out_generic = run_dsp(*generic_dsp, input, block);
+    const auto out_fast = run_dsp(*fast_dsp, input, block);
+    // 1e-5 is what nam2c_verify.py uses as its byte-exactness threshold; allow a little
+    // slack because the generic path sums through Eigen and may reorder FMAs.
+    compare(out_generic, out_fast, channels, block, /*tol=*/5e-5);
+  }
+}
+
+void test_matches_generic_nano()
+{
+  test_matches_generic(3);
+}
+
+void test_matches_generic_standard()
+{
+  test_matches_generic(8);
+}
+
+} // namespace test_a2_fast
+
+#endif // NAM_ENABLE_A2_FAST

--- a/tools/test/test_a2_fast.cpp
+++ b/tools/test/test_a2_fast.cpp
@@ -6,11 +6,15 @@
 
 #if defined(NAM_ENABLE_A2_FAST)
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <random>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "json.hpp"

--- a/tools/test/test_a2_fast.cpp
+++ b/tools/test/test_a2_fast.cpp
@@ -19,6 +19,8 @@
 #include "NAM/wavenet/a2_fast.h"
 #include "NAM/wavenet/model.h"
 
+#include "allocation_tracking.h"
+
 namespace test_a2_fast
 {
 namespace
@@ -252,6 +254,73 @@ void test_matches_generic_nano()
 void test_matches_generic_standard()
 {
   test_matches_generic(8);
+}
+
+// Real-time safety: once the DSP has been Reset (buffers sized, prewarmed),
+// subsequent process() calls must not allocate or free heap memory. Uses the
+// same allocation-tracking infrastructure as the generic WaveNet RT-safety
+// tests (tools/test/allocation_tracking.{h,cpp}) — overridden malloc/free and
+// global new/delete increment counters while tracking is enabled.
+void test_process_realtime_safe(int channels)
+{
+  const auto cfg = build_a2_config(channels);
+  const int weight_count = a2_weight_count(channels);
+  const auto weights = make_deterministic_weights(weight_count, /*seed=*/0xA2FA500u + channels);
+
+  auto fast_cfg = nam::wavenet::a2_fast::create_a2_fast_config(cfg, 48000.0);
+  std::vector<float> w_fast = weights;
+  auto fast_dsp = fast_cfg->create(std::move(w_fast), 48000.0);
+
+  // Exercise several block sizes all within a single pre-sized state so the
+  // internal "num_frames > max_buffer_size" guard in process() never fires
+  // (which would legitimately reallocate).
+  const int max_buffer = 256;
+  fast_dsp->Reset(48000.0, max_buffer);
+
+  const int total = 4 * max_buffer;
+  const auto input = make_test_input(total, 48000.0);
+  std::vector<NAM_SAMPLE> output(total, 0.0);
+
+  // Warm up caches / any lazy init with one untracked pass.
+  {
+    const NAM_SAMPLE* in = input.data();
+    NAM_SAMPLE* out = output.data();
+    const NAM_SAMPLE* in_arr[] = {in};
+    NAM_SAMPLE* out_arr[] = {out};
+    fast_dsp->process(const_cast<NAM_SAMPLE**>(in_arr), out_arr, max_buffer);
+  }
+
+  for (int block : {1, 32, 64, 128, 256})
+  {
+    std::string test_name = "A2FastModel<" + std::to_string(channels) + ">::process block="
+                            + std::to_string(block);
+    allocation_tracking::run_allocation_test_no_allocations(
+      nullptr,
+      [&]() {
+        int pos = 0;
+        while (pos + block <= total)
+        {
+          const NAM_SAMPLE* in = input.data() + pos;
+          NAM_SAMPLE* out = output.data() + pos;
+          const NAM_SAMPLE* in_arr[] = {in};
+          NAM_SAMPLE* out_arr[] = {out};
+          fast_dsp->process(const_cast<NAM_SAMPLE**>(in_arr), out_arr, block);
+          pos += block;
+        }
+      },
+      nullptr,
+      test_name.c_str());
+  }
+}
+
+void test_process_realtime_safe_nano()
+{
+  test_process_realtime_safe(3);
+}
+
+void test_process_realtime_safe_standard()
+{
+  test_process_realtime_safe(8);
 }
 
 } // namespace test_a2_fast


### PR DESCRIPTION
# A2 fast-path WaveNet

Adds a specialized forward-pass implementation for the A2 standard and A2 nano amp models, routed automatically when a `.nam` file matches the A2 shape. The generic WaveNet path is unchanged — it remains the default for everything else, and there's a CMake opt-out (`-DNAM_ENABLE_A2_FAST=OFF`) that disables the specialization entirely.

## Why

The generic `nam::wavenet::WaveNet` is a fully general WaveNet: it supports multiple layer arrays, any channel count, any kernel size, any dilation, gating / FiLM / head1x1 / grouped convolutions, optional post-stack heads, dynamic buffer resizing. All of that flexibility costs something — even for a model that uses none of it. A2 nano and A2 standard share the same fixed architecture: 23 layers, LeakyReLU(0.01), no gating/FiLM/head1x1, `layer1x1` active, kernel sizes `{6, 15}`, head conv `k=16 bias=true`, and channels ∈ {3, 8}. For those two models we can cut out all the dynamism and pick a loop structure tuned to the channel count.

## What's in the PR

1. **Strict A2 shape detector** (`NAM/wavenet/a2_fast.h`, `a2_fast.cpp`) — checks every knob against the A2 signature. If any field is off by one bit, it falls through to the generic path. Never silently routes a non-A2 model to the fast path.

2. **`A2FastModel<Channels>` template DSP** (`a2_fast.cpp`) with explicit instantiations for `Channels = 3` and `Channels = 8`. Shared by both specializations:
   - Column-major per-tap weight storage with a dedicated `_load_weights` that reads the stream in the same order the generic path does (including the trailing `head_scale` that `WaveNet::set_weights_` consumes).
   - Pre-allocated work buffers sized in `SetMaxBufferSize`, nothing resizes during `process()`.
   - Power-of-2 ring buffers with a `max_buffer_size`-wide tail mirror, so reads spanning past the wrap land in contiguous memory (no memmove-rewind jitter, constant-time write + read).

   Two internal strategies, dispatched at compile time on `Channels`:
   - **Channels ≤ 4 (A2 nano)**: hand-unrolled 3×3 GEMV with all 9 weights lifted into named `const float` locals and the c-reduction kept in scalar temps `a0/a1/a2`. Tap 0 seeds `z` directly from `conv_b` (skipping the memset-to-zero pass). Final tap + mixin + LeakyReLU + `head_sum` accumulate + layer1x1 residual all inlined into a single loop on register-resident scalars. Matches the structure `nam2c --fused` generates for the same shape.
   - **Channels ≥ 8 (A2 standard)**: Eigen fixed-LHS block GEMM (`Eigen::Matrix<float, 8, Eigen::Dynamic>`), one 8×8 × 8×num_frames GEMM per tap into a ring-buffer view, then block-wise `colwise() +=` for bias, rank-1 outer product for mixin, elementwise `.select()` for LeakyReLU, another 8×8 × 8×num_frames GEMM for the layer1x1 residual. Leans into Eigen's tuned GEMM kernel for the size that has one, strips everything around it.

   Kernel size is a template parameter (`_layer_forward_k<6>` / `_layer_forward_k<15>`) dispatched by a `switch` on `L.kernel_size`, so the tap loop and per-tap weight offsets are compile-time constants.

3. **Dispatcher hook** (`wavenet/model.cpp::create_config`) — one new `if (is_a2_shape(...)) return create_a2_fast_config(...)` right after the existing slimmable-wavenet branch and before the generic path. Gated on `NAM_ENABLE_A2_FAST`.

4. **C++ verification harness** (`tools/test/test_a2_fast.cpp`) — 6 detector tests (accept nano/standard, reject tweaks to channels / kernel_sizes / activation / gating) plus 2 equivalence tests that build both paths from the same config and weights and assert the outputs match to 5e-5 on a two-tone input, at block sizes 64 and 256. Runs as part of `run_tests` under `#if defined(NAM_ENABLE_A2_FAST)`.

5. **Benchmark tool** (`tools/bench_a2_fast`) — loads a `.nam`, builds both fast and generic DSPs from the same weights, times each block separately (not per-iteration), and reports min / p50 / p99 / p99.9 / max / mean plus RTF.

## Numbers

Apple Silicon M1, `block=64`, 75,000 blocks per variant, released (`-Ofast`). Per-block timing in microseconds (lower is better):

### A2 nano (Channels = 3)

| path | p50 | p99 | p99.9 | max | RTF | vs generic Eigen |
|---|---|---|---|---|---|---|
| Generic WaveNet (Eigen) | 27.3 | 34.1 | 44.8 | 105 | 49× | 1.00× |
| Generic WaveNet (`NAM_USE_INLINE_GEMM`) | 6.8 | 8.9 | 15.2 | 52 | 198× | 4.04× |
| **a2_fast (this PR)** | **4.4** | **5.5** | **11.6** | **24** | **307×** | **6.23×** |
| nam2c `--fused` (for reference) | 4.0 | 5.0 | 13.0 | 23 | 333× | ~6.8× |

### A2 standard (Channels = 8)

| path | p50 | p99 | p99.9 | max | RTF | vs generic Eigen |
|---|---|---|---|---|---|---|
| Generic WaveNet (`NAM_USE_INLINE_GEMM`) | 38.0 | 45.8 | 56.8 | 107 | 35× | 0.95× |
| Generic WaveNet (Eigen) | 36.0 | 44.1 | 54.9 | 120 | 37× | 1.00× |
| **a2_fast (this PR)** | **31.8** | **38.8** | **49.1** | **99** | **42×** | **1.14×** |

A few observations worth calling out:

- **`NAM_USE_INLINE_GEMM` is a ch=3 win and a ch=8 regression.** The hand-unrolled paths in `conv1d.cpp` cover 3×3 / 4×4 / 6×6 / 8×8 explicitly; the small ones beat Eigen cleanly but the 8×8 case loses to Eigen's GEMM kernel. Explains why that flag isn't the default — and why a single "specialized path" strategy doesn't work across channel counts.
- **Jitter is tighter on the fast path in both regimes** — `max` block time is 24 µs (ch=3) and 99 µs (ch=8), vs 105 µs and 120 µs for generic Eigen. Pow2 rings kill the periodic memmove spike. Still well inside the 1333 µs audio deadline at 48 kHz block=64 for all variants — this matters more for small-block / high-SR configurations than for typical desktop plugins.
- **The ch=3 result is essentially tied with `nam2c --fused`.** We're within 9% at p50 and *better* at p99.9 (10.8 µs vs 13.0 µs). nam2c's generated C is the reasonable ceiling for this kind of code in portable C; we're there.

## What's NOT in this PR (deliberately)

- **No explicit SIMD intrinsics.** Everything stays portable — Eigen handles the NEON/SSE dispatch for the ch=8 GEMMs, and the ch=3 scalar code gets auto-FMA'd at `-Ofast`. I tried fold-expression unrolling as an alternate approach and it regressed ch=8 because it scalarized and blocked clang's auto-vectorizer, so the ch=8 path leans on Eigen's tuned kernel rather than trying to hand-roll one.
- **Q15, LUT activations, DTCM placement, --fast-math approximations.** These are useful on embedded targets (Cortex-M7) but add complexity without gain on desktop. The `A2FastModel` header is a natural home if we want to add them later, but not as part of this PR.
- **Widening the detector.** It's strict on purpose — kernel_sizes and dilations must match the A2 pattern exactly. If a future A2-like variant ships with a different schedule, we'll need a second detector (or to loosen this one with care). The test suite has explicit "rejection" cases for each field, so the boundary is enforced.

## How to try it

```bash
cmake -B build && cmake --build build -j
./build/tools/run_tests                          # includes A2 tests
./build/tools/bench_a2_fast path/to/a2_nano.nam path/to/a2_standard.nam
```

Opt out: `cmake -B build -DNAM_ENABLE_A2_FAST=OFF`.

Developed with support and sponsorship from [TONE3000](https://www.tone3000.com/)
