### PR TITLE
[FEATURE] Extensible version support

### DIFF
--- a/NAM/get_dsp.cpp
+++ b/NAM/get_dsp.cpp
@@ -19,14 +19,12 @@ namespace
 class CoreVersionSupportChecker : public IVersionSupportChecker
 {
 public:
-  bool matches(const std::string& version) const override
-  {
-    static const std::regex semver_regex(R"(^\d+\.\d+\.\d+$)");
-    return std::regex_match(version, semver_regex);
-  }
-
   Supported support(const std::string& version) const override
   {
+    static const std::regex semver_regex(R"(^\d+\.\d+\.\d+$)");
+    if (!std::regex_match(version, semver_regex))
+      return Supported::NO;
+
     const Version parsed = ParseVersion(version);
     const Version latest = ParseVersion(LATEST_FULLY_SUPPORTED_NAM_FILE_VERSION);
     const Version earliest = ParseVersion(EARLIEST_SUPPORTED_NAM_FILE_VERSION);
@@ -106,8 +104,6 @@ Supported is_version_supported(const std::string version)
   Supported best_support = Supported::NO;
   for (const auto& checker : version_support_registry())
   {
-    if (!checker->matches(version))
-      continue;
     const auto candidate_support = checker->support(version);
     if (static_cast<int>(candidate_support) > static_cast<int>(best_support))
       best_support = candidate_support;

--- a/NAM/get_dsp.cpp
+++ b/NAM/get_dsp.cpp
@@ -1,5 +1,7 @@
 #include <fstream>
 #include <iostream>
+#include <mutex>
+#include <regex>
 #include <sstream>
 #include <stdexcept>
 
@@ -11,6 +13,49 @@
 
 namespace nam
 {
+namespace
+{
+
+class CoreVersionSupportChecker : public IVersionSupportChecker
+{
+public:
+  bool matches(const std::string& version) const override
+  {
+    static const std::regex semver_regex(R"(^\d+\.\d+\.\d+$)");
+    return std::regex_match(version, semver_regex);
+  }
+
+  Supported support(const std::string& version) const override
+  {
+    const Version parsed = ParseVersion(version);
+    const Version latest = ParseVersion(LATEST_FULLY_SUPPORTED_NAM_FILE_VERSION);
+    const Version earliest = ParseVersion(EARLIEST_SUPPORTED_NAM_FILE_VERSION);
+
+    if (parsed < earliest)
+      return Supported::NO;
+    if (parsed.major > latest.major || parsed.minor > latest.minor)
+      return Supported::NO;
+    if (latest < parsed)
+      return Supported::PARTIAL;
+    return Supported::YES;
+  }
+};
+
+std::vector<std::shared_ptr<const IVersionSupportChecker>>& version_support_registry()
+{
+  static std::vector<std::shared_ptr<const IVersionSupportChecker>> registry{
+      std::make_shared<CoreVersionSupportChecker>()};
+  return registry;
+}
+
+std::mutex& version_support_registry_mutex()
+{
+  static std::mutex registry_mutex;
+  return registry_mutex;
+}
+
+} // namespace
+
 Version ParseVersion(const std::string& versionStr)
 {
   // Split the version string into major, minor, and patch components
@@ -47,32 +92,42 @@ Version ParseVersion(const std::string& versionStr)
   return Version(major, minor, patch);
 }
 
+void register_version_support_checker(std::shared_ptr<const IVersionSupportChecker> checker)
+{
+  if (!checker)
+    throw std::invalid_argument("version support checker cannot be null");
+  std::lock_guard<std::mutex> lock(version_support_registry_mutex());
+  version_support_registry().push_back(std::move(checker));
+}
+
+Supported is_version_supported(const std::string version)
+{
+  std::lock_guard<std::mutex> lock(version_support_registry_mutex());
+  Supported best_support = Supported::NO;
+  for (const auto& checker : version_support_registry())
+  {
+    if (!checker->matches(version))
+      continue;
+    const auto candidate_support = checker->support(version);
+    if (static_cast<int>(candidate_support) > static_cast<int>(best_support))
+      best_support = candidate_support;
+  }
+  return best_support;
+}
+
 void verify_config_version(const std::string versionStr)
 {
-  Version version = ParseVersion(versionStr);
-  Version currentVersion = ParseVersion(LATEST_FULLY_SUPPORTED_NAM_FILE_VERSION);
-  Version earliestSupportedVersion = ParseVersion(EARLIEST_SUPPORTED_NAM_FILE_VERSION);
-
-  if (version < earliestSupportedVersion)
+  const Supported support = is_version_supported(versionStr);
+  if (support == Supported::NO)
   {
     std::stringstream ss;
-    ss << "Model config is an unsupported version " << versionStr << ". The earliest supported version is "
-       << earliestSupportedVersion.toString()
-       << ". Try either converting the model to a more recent version, or "
-          "update your version of the NAM plugin.";
+    ss << "Model config is an unsupported version " << versionStr << ".";
     throw std::runtime_error(ss.str());
   }
-  if (version.major > currentVersion.major || version.minor > currentVersion.minor)
+  if (support == Supported::PARTIAL)
   {
     std::stringstream ss;
-    ss << "Model config is an unsupported version " << versionStr << ". The latest fully-supported version is "
-       << currentVersion.toString();
-    throw std::runtime_error(ss.str());
-  }
-  else if (currentVersion < version)
-  {
     std::cerr << "Model config is a partially-supported version " << versionStr
-              << ". The latest fully-supported version is " << currentVersion.toString()
               << ". Continuing with partial support." << std::endl;
   }
 }

--- a/NAM/get_dsp.h
+++ b/NAM/get_dsp.h
@@ -1,11 +1,28 @@
 #pragma once
 
 #include <fstream>
+#include <memory>
+#include <vector>
 
 #include "dsp.h"
 
 namespace nam
 {
+enum class Supported
+{
+  NO = 0,
+  PARTIAL = 1,
+  YES = 2
+};
+
+class IVersionSupportChecker
+{
+public:
+  virtual ~IVersionSupportChecker() = default;
+  virtual bool matches(const std::string& version) const = 0;
+  virtual Supported support(const std::string& version) const = 0;
+};
+
 class Version
 {
 public:
@@ -39,6 +56,10 @@ public:
 };
 
 Version ParseVersion(const std::string& versionStr);
+
+void register_version_support_checker(std::shared_ptr<const IVersionSupportChecker> checker);
+
+Supported is_version_supported(const std::string version);
 
 void verify_config_version(const std::string versionStr);
 

--- a/NAM/get_dsp.h
+++ b/NAM/get_dsp.h
@@ -19,7 +19,6 @@ class IVersionSupportChecker
 {
 public:
   virtual ~IVersionSupportChecker() = default;
-  virtual bool matches(const std::string& version) const = 0;
   virtual Supported support(const std::string& version) const = 0;
 };
 

--- a/tools/run_tests.cpp
+++ b/tools/run_tests.cpp
@@ -273,6 +273,8 @@ int main()
   test_get_dsp::test_version_patch_one_beyond_supported();
   test_get_dsp::test_version_minor_one_beyond_supported();
   test_get_dsp::test_version_too_early();
+  test_get_dsp::test_is_version_supported_core_behavior();
+  test_get_dsp::test_register_custom_version_support_checker();
 
   // Finally, some end-to-end tests.
   test_get_dsp::test_load_and_process_nam_files();

--- a/tools/test/test_get_dsp.cpp
+++ b/tools/test/test_get_dsp.cpp
@@ -169,6 +169,24 @@ std::string createConfigWithVersion(const std::string& version)
   return j.dump();
 }
 
+class DemoVersionSupportChecker : public nam::IVersionSupportChecker
+{
+public:
+  nam::Supported support(const std::string& version) const override
+  {
+    const std::string prefix = "DEMO::";
+    if (version.rfind(prefix, 0) != 0)
+      return nam::Supported::NO;
+
+    const std::string scopedVersion = version.substr(prefix.size());
+    if (scopedVersion == "1.0.0")
+      return nam::Supported::YES;
+    if (scopedVersion.rfind("1.0.", 0) == 0)
+      return nam::Supported::PARTIAL;
+    return nam::Supported::NO;
+  }
+};
+
 void test_version_patch_one_beyond_supported()
 {
   // Test that a .nam file with version one patch beyond the latest fully supported
@@ -231,5 +249,31 @@ void test_version_too_early()
     threw = true;
   }
   assert(threw);
+}
+
+void test_is_version_supported_core_behavior()
+{
+  assert(nam::is_version_supported(nam::LATEST_FULLY_SUPPORTED_NAM_FILE_VERSION)
+         == nam::Supported::YES);
+
+  nam::Version patchBeyondLatest = nam::ParseVersion(nam::LATEST_FULLY_SUPPORTED_NAM_FILE_VERSION);
+  patchBeyondLatest.patch++;
+  assert(nam::is_version_supported(patchBeyondLatest.toString())
+         == nam::Supported::PARTIAL);
+
+  nam::Version minorBeyondLatest = nam::ParseVersion(nam::LATEST_FULLY_SUPPORTED_NAM_FILE_VERSION);
+  minorBeyondLatest.minor++;
+  minorBeyondLatest.patch = 0;
+  assert(nam::is_version_supported(minorBeyondLatest.toString())
+         == nam::Supported::NO);
+}
+
+void test_register_custom_version_support_checker()
+{
+  nam::register_version_support_checker(std::make_shared<DemoVersionSupportChecker>());
+
+  assert(nam::is_version_supported("DEMO::1.0.0") == nam::Supported::YES);
+  assert(nam::is_version_supported("DEMO::1.0.3") == nam::Supported::PARTIAL);
+  assert(nam::is_version_supported("DEMO::2.0.0") == nam::Supported::NO);
 }
 }; // namespace test_get_dsp


### PR DESCRIPTION
Depending projects can define extensions to supported `"version"`s in .nam files. As demonstrated int eh test, one could for example develop an extension to this repo, develop .nam files with a version `"DEMO::1.0.0"` (and also register their respective DSP subclasses), and still use `get_dsp()` from this repo without worrying that it'll think that it doesn't know how to use the model you point it at. Also allows for different extensions to Core to be developed with independent versioning.

AI PR Description:

## Summary
- Refactors model version validation in `get_dsp` to use a pluggable checker interface (`IVersionSupportChecker`) and a support-level enum (`Supported`: NO/PARTIAL/YES).
- Adds a thread-safe global registry with `register_version_support_checker(...)`, and routes version decisions through `is_version_supported(...)` so core and custom checkers can coexist.
- Preserves current behavior for built-in semver NAM model versions via a default core checker, including partial-support handling and rejection of unsupported versions.
- Adds test coverage for both core support classification and custom checker registration, and wires the new tests into `run_tests`.

## Why
- Enables external/custom architecture ecosystems to define their own version compatibility policies without forking the core loader logic.
- Centralizes support classification so future version logic changes are easier to extend and test.

## Changes
- `NAM/get_dsp.h`
  - Introduces `Supported` enum.
  - Introduces `IVersionSupportChecker` interface.
  - Adds `register_version_support_checker(...)` and `is_version_supported(...)` APIs.
- `NAM/get_dsp.cpp`
  - Implements a default `CoreVersionSupportChecker`.
  - Adds registry + mutex for checker registration/lookups.
  - Refactors `verify_config_version(...)` to use `is_version_supported(...)`.
- `tools/test/test_get_dsp.cpp`
  - Adds `test_is_version_supported_core_behavior`.
  - Adds `test_register_custom_version_support_checker`.
- `tools/run_tests.cpp`
  - Executes the two new tests in the test runner.

## Test Plan
- [x] Build tests: `cmake --build build --target run_tests`
- [x] Run suite: `./build/tools/run_tests`
- [x] Verify success output (`Success!`)
- [x] Confirm new `test_get_dsp` cases execute in `run_tests`