### PR TITLE
[BUGFIX] Fix container slimmable prewarming

### DIFF
--- a/NAM/container.cpp
+++ b/NAM/container.cpp
@@ -69,18 +69,25 @@ void ContainerModel::Reset(const double sampleRate, const int maxBufferSize)
 
 void ContainerModel::SetSlimmableSize(const double val)
 {
-  _active_index = _submodels.size() - 1;
+  auto active_index = _submodels.size() - 1;
   for (size_t i = 0; i < _submodels.size(); ++i)
   {
     if (val < _submodels[i].max_value)
     {
-      _active_index = i;
+      active_index = i;
       break;
     }
   }
-
+  if (active_index == _active_index) // No change to active model, so nothing to do
+  {
+    return;
+  }
+  // Setting _active_index puts the model in the RT path, so prewarm before doing that
   const double sr = mHaveExternalSampleRate ? mExternalSampleRate : mExpectedSampleRate;
-  _active_model().ResetAndPrewarm(sr, GetMaxBufferSize());
+  _submodels[active_index].model->ResetAndPrewarm(sr, GetMaxBufferSize());
+
+  // Finally set when we're ready:
+  _active_index = active_index;
 }
 
 // =============================================================================

--- a/tools/test/test_container.cpp
+++ b/tools/test/test_container.cpp
@@ -314,6 +314,8 @@ void test_container_default_is_max_size()
   NAM_SAMPLE* in_ptr = input.data();
   NAM_SAMPLE* out_ptr;
 
+  // Ensure both predictions start from identical model state.
+  dsp->ResetAndPrewarm(sample_rate, buffer_size);
   // Process with default (should be max size)
   out_ptr = out_default.data();
   dsp->process(&in_ptr, &out_ptr, buffer_size);
@@ -322,6 +324,7 @@ void test_container_default_is_max_size()
   auto* slimmable = dynamic_cast<nam::SlimmableModel*>(dsp.get());
   assert(slimmable != nullptr);
   slimmable->SetSlimmableSize(1.0);
+  dsp->ResetAndPrewarm(sample_rate, buffer_size);
   out_ptr = out_max.data();
   dsp->process(&in_ptr, &out_ptr, buffer_size);
 


### PR DESCRIPTION
Fixes a bug where `SetSlimmbaleSize` would trigger a reset-and-prewarm even if the selected model was the one that was already active.

