### PR TITLE
[BUGFIX] Make ContainerModel::SetSlimmableSize thread-safe

### DIFF
--- a/NAM/container.cpp
+++ b/NAM/container.cpp
@@ -69,18 +69,25 @@ void ContainerModel::Reset(const double sampleRate, const int maxBufferSize)
 
 void ContainerModel::SetSlimmableSize(const double val)
 {
-  _active_index = _submodels.size() - 1;
+  auto active_index = _submodels.size() - 1;
   for (size_t i = 0; i < _submodels.size(); ++i)
   {
     if (val < _submodels[i].max_value)
     {
-      _active_index = i;
+      active_index = i;
       break;
     }
   }
-
+  if (active_index == _active_index) // No change to active model, so nothing to do
+  {
+    return;
+  }
+  // Setting _active_index puts the model in the RT path, so prewarm before doing that
   const double sr = mHaveExternalSampleRate ? mExternalSampleRate : mExpectedSampleRate;
-  _active_model().ResetAndPrewarm(sr, GetMaxBufferSize());
+  _submodels[active_index].model->ResetAndPrewarm(sr, GetMaxBufferSize());
+
+  // Finally set when we're ready:
+  _active_index = active_index;
 }
 
 // =============================================================================

--- a/NAM/container.cpp
+++ b/NAM/container.cpp
@@ -51,7 +51,8 @@ ContainerModel::ContainerModel(std::vector<Submodel> submodels, const double exp
 
 void ContainerModel::process(NAM_SAMPLE** input, NAM_SAMPLE** output, const int num_frames)
 {
-  _active_model().process(input, output, num_frames);
+  const size_t active_index = _active_index.load(std::memory_order_acquire);
+  _submodels[active_index].model->process(input, output, num_frames);
 }
 
 void ContainerModel::prewarm()
@@ -69,7 +70,7 @@ void ContainerModel::Reset(const double sampleRate, const int maxBufferSize)
 
 void ContainerModel::SetSlimmableSize(const double val)
 {
-  auto active_index = _submodels.size() - 1;
+  size_t active_index = _submodels.size() - 1;
   for (size_t i = 0; i < _submodels.size(); ++i)
   {
     if (val < _submodels[i].max_value)
@@ -78,16 +79,27 @@ void ContainerModel::SetSlimmableSize(const double val)
       break;
     }
   }
-  if (active_index == _active_index) // No change to active model, so nothing to do
+
+  // Fast path: no change to active model.
+  if (active_index == _active_index.load(std::memory_order_acquire))
   {
     return;
   }
+
+  // Plugin host can deliver param changes from both UI/controller and processor paths.
+  // Serialize reset+prewarm so only one thread can perform model activation at a time.
+  std::lock_guard<std::mutex> lock(_slim_set_mutex);
+  if (active_index == _active_index.load(std::memory_order_acquire))
+  {
+    return;
+  }
+
   // Setting _active_index puts the model in the RT path, so prewarm before doing that
   const double sr = mHaveExternalSampleRate ? mExternalSampleRate : mExpectedSampleRate;
   _submodels[active_index].model->ResetAndPrewarm(sr, GetMaxBufferSize());
 
   // Finally set when we're ready:
-  _active_index = active_index;
+  _active_index.store(active_index, std::memory_order_release);
 }
 
 // =============================================================================

--- a/NAM/container.h
+++ b/NAM/container.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <vector>
 
@@ -42,9 +44,8 @@ protected:
 
 private:
   std::vector<Submodel> _submodels;
-  size_t _active_index = 0;
-
-  DSP& _active_model() { return *_submodels[_active_index].model; }
+  std::atomic<size_t> _active_index{0};
+  std::mutex _slim_set_mutex;
 };
 
 // Config / registration

--- a/tools/test/test_container.cpp
+++ b/tools/test/test_container.cpp
@@ -314,6 +314,8 @@ void test_container_default_is_max_size()
   NAM_SAMPLE* in_ptr = input.data();
   NAM_SAMPLE* out_ptr;
 
+  // Ensure both predictions start from identical model state.
+  dsp->ResetAndPrewarm(sample_rate, buffer_size);
   // Process with default (should be max size)
   out_ptr = out_default.data();
   dsp->process(&in_ptr, &out_ptr, buffer_size);
@@ -322,6 +324,7 @@ void test_container_default_is_max_size()
   auto* slimmable = dynamic_cast<nam::SlimmableModel*>(dsp.get());
   assert(slimmable != nullptr);
   slimmable->SetSlimmableSize(1.0);
+  dsp->ResetAndPrewarm(sample_rate, buffer_size);
   out_ptr = out_max.data();
   dsp->process(&in_ptr, &out_ptr, buffer_size);
 


### PR DESCRIPTION
Bug discovered from multiple threads calling `SetSlimmableSize()` (UI and processor threads). Both would end up calling `Reset` and cause massive issues with internal state as prewarming was attempted.

Fix with a mutex to make it thread-safe.