### PR TITLE
Fix GCC 9.4 build: gate std::atomic<shared_ptr> on C++20 feature macro

### DIFF
--- a/NAM/wavenet/slimmable.cpp
+++ b/NAM/wavenet/slimmable.cpp
@@ -291,27 +291,7 @@ bool is_full_size(const std::vector<wavenet::LayerArrayParams>& params, const st
 
 } // anonymous namespace
 
-#ifdef _LIBCPP_VERSION
-void SlimmableWavenet::_pending_clear_release()
-{
-  std::atomic_store_explicit(&_pending_staged, std::shared_ptr<StagedSlimModel>{}, std::memory_order_release);
-}
-
-std::shared_ptr<SlimmableWavenet::StagedSlimModel> SlimmableWavenet::_pending_load_acquire() const
-{
-  return std::atomic_load_explicit(&_pending_staged, std::memory_order_acquire);
-}
-
-void SlimmableWavenet::_pending_store_release(std::shared_ptr<StagedSlimModel> p)
-{
-  std::atomic_store_explicit(&_pending_staged, std::move(p), std::memory_order_release);
-}
-
-std::shared_ptr<SlimmableWavenet::StagedSlimModel> SlimmableWavenet::_pending_exchange_take_acq_rel()
-{
-  return std::atomic_exchange_explicit(&_pending_staged, std::shared_ptr<StagedSlimModel>{}, std::memory_order_acq_rel);
-}
-#else
+#if NAM_HAS_ATOMIC_SHARED_PTR
 void SlimmableWavenet::_pending_clear_release()
 {
   _pending_staged.store({}, std::memory_order_release);
@@ -330,6 +310,26 @@ void SlimmableWavenet::_pending_store_release(std::shared_ptr<StagedSlimModel> p
 std::shared_ptr<SlimmableWavenet::StagedSlimModel> SlimmableWavenet::_pending_exchange_take_acq_rel()
 {
   return _pending_staged.exchange({}, std::memory_order_acq_rel);
+}
+#else
+void SlimmableWavenet::_pending_clear_release()
+{
+  std::atomic_store_explicit(&_pending_staged, std::shared_ptr<StagedSlimModel>{}, std::memory_order_release);
+}
+
+std::shared_ptr<SlimmableWavenet::StagedSlimModel> SlimmableWavenet::_pending_load_acquire() const
+{
+  return std::atomic_load_explicit(&_pending_staged, std::memory_order_acquire);
+}
+
+void SlimmableWavenet::_pending_store_release(std::shared_ptr<StagedSlimModel> p)
+{
+  std::atomic_store_explicit(&_pending_staged, std::move(p), std::memory_order_release);
+}
+
+std::shared_ptr<SlimmableWavenet::StagedSlimModel> SlimmableWavenet::_pending_exchange_take_acq_rel()
+{
+  return std::atomic_exchange_explicit(&_pending_staged, std::shared_ptr<StagedSlimModel>{}, std::memory_order_acq_rel);
 }
 #endif
 

--- a/NAM/wavenet/slimmable.h
+++ b/NAM/wavenet/slimmable.h
@@ -3,9 +3,19 @@
 #include <memory>
 #include <vector>
 
-#ifdef _LIBCPP_VERSION
-// libc++: std::atomic<std::shared_ptr<T>> is not viable; staging uses deprecated atomic_* free functions.
+// std::atomic<std::shared_ptr<T>> requires C++20 library support (libstdc++ >= GCC 12).
+// Where it is unavailable -- libc++ (any version so far) and older libstdc++ such as the
+// one shipped with GCC 9 -- fall back to the deprecated std::atomic_* free-function
+// overloads for shared_ptr, which provide the same acquire/release semantics. Keyed on the
+// C++20 feature-test macro rather than on a specific standard library so the right path is
+// chosen for every compiler.
+#if defined(__cpp_lib_atomic_shared_ptr) && __cpp_lib_atomic_shared_ptr >= 201711L
+  #define NAM_HAS_ATOMIC_SHARED_PTR 1
 #else
+  #define NAM_HAS_ATOMIC_SHARED_PTR 0
+#endif
+
+#if NAM_HAS_ATOMIC_SHARED_PTR
   #include <atomic>
 #endif
 
@@ -71,11 +81,11 @@ private:
     std::shared_ptr<DSP> model;
     std::vector<int> channels;
   };
-#ifdef _LIBCPP_VERSION
+#if NAM_HAS_ATOMIC_SHARED_PTR
+  std::atomic<std::shared_ptr<StagedSlimModel>> _pending_staged;
+#else
   /// Staged model; synchronized via deprecated std::atomic_* overloads for shared_ptr only.
   std::shared_ptr<StagedSlimModel> _pending_staged;
-#else
-  std::atomic<std::shared_ptr<StagedSlimModel>> _pending_staged;
 #endif
 
   std::vector<int> _current_channels;


### PR DESCRIPTION
## Problem

This project fails to build under GCC 9.4.0 because `NAM/wavenet/slimmable.h` uses `std::atomic<std::shared_ptr<T>>`, a C++20 library feature that **libstdc++** only supports from GCC 12.

The header already had a fallback to the deprecated `std::atomic_*` free-function overloads for `shared_ptr`, but it was keyed on `#ifdef _LIBCPP_VERSION`. GCC 9.4 uses **libstdc++** (not libc++), so it took the `#else` branch and required the unsupported `std::atomic<std::shared_ptr<>>`.

## Fix

Key the selection on the standard C++20 feature-test macro `__cpp_lib_atomic_shared_ptr` instead of on a specific standard library:

```cpp
#if defined(__cpp_lib_atomic_shared_ptr) && __cpp_lib_atomic_shared_ptr >= 201711L
  #define NAM_HAS_ATOMIC_SHARED_PTR 1
#else
  #define NAM_HAS_ATOMIC_SHARED_PTR 0
#endif
```

- **GCC 12+ (macro defined)** → unchanged, uses the member `std::atomic<std::shared_ptr<>>` path.
- **libc++ (macro never defined — feature still unimplemented)** → unchanged, uses the free-function fallback exactly as before.
- **GCC 9.4 + libstdc++ (macro undefined)** → now correctly takes the free-function fallback instead of failing to compile.

No behavior change for any compiler that previously built.

## Files changed

- `NAM/wavenet/slimmable.h` — feature-macro guard, conditional include, member declaration.
- `NAM/wavenet/slimmable.cpp` — the four staging accessor definitions.
