### PR TITLE
Restore `ResetAndPrewarm` as a deprecated shim

### DIFF
--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -19,6 +19,26 @@ namespace
 
 thread_local bool gPrewarmOnResetDefault = true;
 
+class ScopedDSPPrewarmOnReset
+{
+public:
+  ScopedDSPPrewarmOnReset(nam::DSP& dsp, const bool prewarmOnReset)
+  : mDSP(dsp)
+  , mPreviousPrewarmOnReset(dsp.GetPrewarmOnReset())
+  {
+    mDSP.SetPrewarmOnReset(prewarmOnReset);
+  }
+
+  ~ScopedDSPPrewarmOnReset() { mDSP.SetPrewarmOnReset(mPreviousPrewarmOnReset); }
+
+  ScopedDSPPrewarmOnReset(const ScopedDSPPrewarmOnReset&) = delete;
+  ScopedDSPPrewarmOnReset& operator=(const ScopedDSPPrewarmOnReset&) = delete;
+
+private:
+  nam::DSP& mDSP;
+  bool mPreviousPrewarmOnReset;
+};
+
 } // namespace
 
 nam::ScopedPrewarmOnResetDefault::ScopedPrewarmOnResetDefault(const bool prewarmOnReset)
@@ -117,6 +137,12 @@ void nam::DSP::Reset(const double sampleRate, const int maxBufferSize)
 
   if (GetPrewarmOnReset())
     prewarm();
+}
+
+void nam::DSP::ResetAndPrewarm(const double sampleRate, const int maxBufferSize)
+{
+  ScopedDSPPrewarmOnReset scoped_prewarm_on_reset(*this, true);
+  Reset(sampleRate, maxBufferSize);
 }
 
 void nam::DSP::SetPrewarmOnReset(const bool prewarmOnReset)

--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -165,6 +165,14 @@ public:
   /// \param maxBufferSize Maximum buffer size to process
   virtual void Reset(const double sampleRate, const int maxBufferSize);
 
+  /// \brief Reset the DSP unit, then prewarm
+  ///
+  /// Deprecated: ResetAndPrewarm() will be removed in v0.6.0. Reset() prewarms by default; use
+  /// SetPrewarmOnReset() to control whether Reset() calls prewarm().
+  /// \param sampleRate Current sample rate
+  /// \param maxBufferSize Maximum buffer size to process
+  void ResetAndPrewarm(const double sampleRate, const int maxBufferSize);
+
   /// \brief Control whether Reset() calls prewarm()
   /// \param prewarmOnReset true for Reset() to call prewarm(), false to skip prewarm()
   virtual void SetPrewarmOnReset(const bool prewarmOnReset);

--- a/tools/run_tests.cpp
+++ b/tools/run_tests.cpp
@@ -86,6 +86,8 @@ int main()
   test_dsp::test_set_output_level();
   test_dsp::test_reset_prewarm_on_reset_default();
   test_dsp::test_set_prewarm_on_reset();
+  test_dsp::test_reset_and_prewarm_forces_prewarm();
+  test_dsp::test_reset_and_prewarm_restores_prewarm_on_throw();
   test_dsp::test_scoped_prewarm_on_reset_default();
 
   test_linear::test_direct_known_values();

--- a/tools/test/test_dsp.cpp
+++ b/tools/test/test_dsp.cpp
@@ -2,6 +2,7 @@
 
 #include "NAM/dsp.h"
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 namespace test_dsp
@@ -17,6 +18,17 @@ public:
   void prewarm() override { prewarm_count++; }
 
   int prewarm_count = 0;
+};
+
+class ThrowingResetDSP : public PrewarmCountingDSP
+{
+public:
+  void Reset(const double sampleRate, const int maxBufferSize) override
+  {
+    (void)sampleRate;
+    (void)maxBufferSize;
+    throw std::runtime_error("Reset failed");
+  }
 };
 
 // Simplest test: can I construct something!
@@ -126,6 +138,36 @@ void test_set_prewarm_on_reset()
   dsp.SetPrewarmOnReset(true);
   dsp.Reset(48000.0, 64);
   assert(dsp.prewarm_count == 1);
+}
+
+void test_reset_and_prewarm_forces_prewarm()
+{
+  PrewarmCountingDSP dsp;
+  dsp.SetPrewarmOnReset(false);
+
+  dsp.ResetAndPrewarm(48000.0, 64);
+
+  assert(dsp.prewarm_count == 1);
+  assert(!dsp.GetPrewarmOnReset());
+}
+
+void test_reset_and_prewarm_restores_prewarm_on_throw()
+{
+  ThrowingResetDSP dsp;
+  dsp.SetPrewarmOnReset(false);
+
+  bool threw = false;
+  try
+  {
+    dsp.ResetAndPrewarm(48000.0, 64);
+  }
+  catch (const std::runtime_error&)
+  {
+    threw = true;
+  }
+
+  assert(threw);
+  assert(!dsp.GetPrewarmOnReset());
 }
 
 void test_scoped_prewarm_on_reset_default()


### PR DESCRIPTION
## Summary

Adds a temporary `DSP::ResetAndPrewarm()` compatibility shim on top of the new `Reset()` prewarm controls.

`Reset()` now prewarms by default and can be controlled with `SetPrewarmOnReset()`. This PR restores the old explicit `ResetAndPrewarm()` API as a deprecated helper so downstream callers have a migration path before removal in `v0.6.0`.

## Changes

- Adds `DSP::ResetAndPrewarm(sampleRate, maxBufferSize)`.
- Implements it by temporarily forcing `prewarmOnReset = true`, calling `Reset()`, then restoring the previous setting.
- Uses RAII so the previous setting is restored if `Reset()` throws.
- Adds tests for:
  - forcing prewarm when `PrewarmOnReset` is disabled
  - restoring the previous setting on exception

## Testing

```sh
cmake --build build --target run_tests -j4
./build/tools/run_tests