### PR TITLE
Add dilation for WaveNet layer array head

### DIFF
--- a/NAM/wavenet/a2_fast.cpp
+++ b/NAM/wavenet/a2_fast.cpp
@@ -977,6 +977,8 @@ bool is_a2_shape(const nlohmann::json& config, int* channels)
     return false;
   if (lah_it->value("kernel_size", 0) != kHeadKernelSize)
     return false;
+  if (lah_it->value("head_dilation", 1) != 1)
+    return false;
   if (!lah_it->value("bias", false))
     return false;
 

--- a/NAM/wavenet/model.cpp
+++ b/NAM/wavenet/model.cpp
@@ -419,7 +419,7 @@ long nam::wavenet::detail::LayerArray::get_receptive_field() const
   long result = 0;
   for (size_t i = 0; i < this->_layers.size(); i++)
     result += this->_layers[i].get_dilation() * (this->_layers[i].get_kernel_size() - 1);
-  result += (long)this->_head_rechannel.get_kernel_size() - 1;
+  result += this->_head_rechannel.get_dilation() * (long)this->_head_rechannel.get_kernel_size() - 1;
   return result;
 }
 

--- a/NAM/wavenet/model.cpp
+++ b/NAM/wavenet/model.cpp
@@ -380,7 +380,7 @@ void nam::wavenet::detail::Layer::Process(const Eigen::MatrixXf& input, const Ei
 nam::wavenet::detail::LayerArray::LayerArray(const LayerArrayParams& params)
 : _rechannel(params.input_size, params.channels, false)
 , _head_rechannel(params.head1x1_params.active ? params.head1x1_params.out_channels : params.bottleneck,
-                  params.head_size, params.head_kernel_size, params.head_bias ? 1 : 0, 1, 1)
+                  params.head_size, params.head_kernel_size, params.head_bias ? 1 : 0, params.head_dilation, 1)
 , _head_output_size(params.head1x1_params.active ? params.head1x1_params.out_channels : params.bottleneck)
 {
   const size_t num_layers = params.dilations.size();
@@ -876,6 +876,7 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
     const int condition_size = layer_config["condition_size"];
 
     int head_size = 0;
+    int head_dilation = 1;
     int head_kernel_size = 1;
     bool head_bias = false;
 
@@ -888,6 +889,12 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
         throw std::runtime_error("Layer array " + std::to_string(i) + ": 'head' must be a JSON object");
       }
       head_size = head_json.at("out_channels").get<int>();
+
+      if (head_json.contains("head_dilation"))
+      {
+        head_dilation = head_json.at("head_dilation").get<int>();
+      }
+
       head_kernel_size = head_json.at("kernel_size").get<int>();
       head_bias = head_json.at("bias").get<bool>();
     }
@@ -1144,7 +1151,7 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
     }
 
     wc.layer_array_params.push_back(nam::wavenet::LayerArrayParams(
-      input_size, condition_size, head_size, head_kernel_size, channels, bottleneck, std::move(kernel_sizes), dilations,
+      input_size, condition_size, head_size, head_dilation, head_kernel_size, channels, bottleneck, std::move(kernel_sizes), dilations,
       std::move(activation_configs), std::move(gating_modes), head_bias, groups, groups_input_mixin, layer1x1_params,
       head1x1_params, std::move(secondary_activation_configs), conv_pre_film_params, conv_post_film_params,
       input_mixin_pre_film_params, input_mixin_post_film_params, activation_pre_film_params,

--- a/NAM/wavenet/model.cpp
+++ b/NAM/wavenet/model.cpp
@@ -419,7 +419,7 @@ long nam::wavenet::detail::LayerArray::get_receptive_field() const
   long result = 0;
   for (size_t i = 0; i < this->_layers.size(); i++)
     result += this->_layers[i].get_dilation() * (this->_layers[i].get_kernel_size() - 1);
-  result += this->_head_rechannel.get_dilation() * (long)this->_head_rechannel.get_kernel_size() - 1;
+  result += this->_head_rechannel.get_dilation() * ((long)this->_head_rechannel.get_kernel_size() - 1);
   return result;
 }
 

--- a/NAM/wavenet/params.h
+++ b/NAM/wavenet/params.h
@@ -181,6 +181,7 @@ public:
   /// \param input_size_ Input size (number of channels) to the layer array
   /// \param condition_size_ Size of the conditioning input
   /// \param head_size_ Size of the head output (after head rechannel)
+  /// \param head_dilation_ Dilation of the head rechannel convolution
   /// \param channels_ Number of channels in each layer
   /// \param bottleneck_ Bottleneck size (internal channel count)
   /// \param kernel_sizes_ Per-layer kernel sizes, one per layer

--- a/NAM/wavenet/params.h
+++ b/NAM/wavenet/params.h
@@ -204,7 +204,7 @@ public:
   /// \param head1x1_post_film_params_ FiLM parameters after head1x1 convolutions
   /// \throws std::invalid_argument If dilations, activation_configs, gating_modes, or secondary_activation_configs
   /// sizes don't match
-  LayerArrayParams(const int input_size_, const int condition_size_, const int head_size_, const int head_kernel_size_,
+  LayerArrayParams(const int input_size_, const int condition_size_, const int head_size_, const int head_dilation_, const int head_kernel_size_,
                    const int channels_, const int bottleneck_, const std::vector<int>&& kernel_sizes_,
                    const std::vector<int>&& dilations_,
                    const std::vector<activations::ActivationConfig>&& activation_configs_,
@@ -219,6 +219,7 @@ public:
   : input_size(input_size_)
   , condition_size(condition_size_)
   , head_size(head_size_)
+  , head_dilation(head_dilation_)
   , head_kernel_size(head_kernel_size_)
   , channels(channels_)
   , bottleneck(bottleneck_)
@@ -277,6 +278,7 @@ public:
   const int input_size; ///< Input size (number of channels)
   const int condition_size; ///< Size of conditioning input
   const int head_size; ///< Size of head output (after rechannel)
+  const int head_dilation;
   const int head_kernel_size; ///< Kernel size of head rechannel convolution (>= 1)
   const int channels; ///< Number of channels in each layer
   const int bottleneck; ///< Bottleneck size (internal channel count)

--- a/NAM/wavenet/params.h
+++ b/NAM/wavenet/params.h
@@ -278,7 +278,7 @@ public:
   const int input_size; ///< Input size (number of channels)
   const int condition_size; ///< Size of conditioning input
   const int head_size; ///< Size of head output (after rechannel)
-  const int head_dilation;
+  const int head_dilation; ///< Dilation of the head rechannel convolution
   const int head_kernel_size; ///< Kernel size of head rechannel convolution (>= 1)
   const int channels; ///< Number of channels in each layer
   const int bottleneck; ///< Bottleneck size (internal channel count)

--- a/NAM/wavenet/slimmable.cpp
+++ b/NAM/wavenet/slimmable.cpp
@@ -265,7 +265,7 @@ std::vector<wavenet::LayerArrayParams> modify_params_for_channels(
     int new_head_size = (i < num_arrays - 1) ? new_channels_per_array[i + 1] : p.head_size;
 
     modified.push_back(wavenet::LayerArrayParams(
-      new_input_size, p.condition_size, new_head_size, p.head_kernel_size, new_ch, new_bottleneck,
+      new_input_size, p.condition_size, new_head_size, p.head_dilation, p.head_kernel_size, new_ch, new_bottleneck,
       std::vector<int>(p.kernel_sizes), std::vector<int>(p.dilations),
       std::vector<activations::ActivationConfig>(p.activation_configs),
       std::vector<wavenet::GatingMode>(p.gating_modes), p.head_bias, p.groups_input, p.groups_input_mixin,

--- a/tools/run_tests.cpp
+++ b/tools/run_tests.cpp
@@ -182,6 +182,7 @@ int main()
   test_wavenet::test_output_head::test_wavenet_with_two_layer_post_stack_head_applies_activation_per_layer_input();
   test_wavenet::test_layer_head_config::test_legacy_head_size_and_head_bias_implies_kernel_one();
   test_wavenet::test_layer_head_config::test_nested_head_with_kernel_size_three();
+  test_wavenet::test_layer_head_config::test_nested_head_with_dilation_three();
   test_wavenet::test_full::test_wavenet_multiple_arrays();
   test_wavenet::test_full::test_wavenet_zero_input();
   test_wavenet::test_full::test_wavenet_different_buffer_sizes();

--- a/tools/test/test_wavenet/test_condition_processing.cpp
+++ b/tools/test/test_wavenet/test_condition_processing.cpp
@@ -36,7 +36,7 @@ static nam::wavenet::LayerArrayParams make_layer_array_params(
   std::vector<nam::activations::ActivationConfig> secondary_activation_configs(
     dilations.size(), secondary_activation_config);
   return nam::wavenet::LayerArrayParams(
-    input_size, condition_size, head_size, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations),
+    input_size, condition_size, head_size, 1, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations),
     std::move(activation_configs), std::move(gating_modes), head_bias, groups_input, groups_input_mixin,
     layer1x1_params, head1x1_params, std::move(secondary_activation_configs), film_params, film_params, film_params,
     film_params, film_params, film_params, film_params, film_params);

--- a/tools/test/test_wavenet/test_full.cpp
+++ b/tools/test/test_wavenet/test_full.cpp
@@ -35,7 +35,7 @@ static nam::wavenet::LayerArrayParams make_layer_array_params(
   std::vector<nam::activations::ActivationConfig> secondary_activation_configs(
     dilations.size(), secondary_activation_config);
   return nam::wavenet::LayerArrayParams(
-    input_size, condition_size, head_size, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations),
+    input_size, condition_size, head_size, 1, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations),
     std::move(activation_configs), std::move(gating_modes), head_bias, groups_input, groups_input_mixin,
     layer1x1_params, head1x1_params, std::move(secondary_activation_configs), film_params, film_params, film_params,
     film_params, film_params, film_params, film_params, film_params);

--- a/tools/test/test_wavenet/test_layer_array.cpp
+++ b/tools/test/test_wavenet/test_layer_array.cpp
@@ -36,7 +36,7 @@ static nam::wavenet::detail::LayerArray make_layer_array(
   std::vector<int> dilations_copy = dilations; // Make a copy since we need to move it
   std::vector<int> kernel_sizes(dilations.size(), kernel_size);
   nam::wavenet::LayerArrayParams params(
-    input_size, condition_size, head_size, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations_copy),
+    input_size, condition_size, head_size, 1, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations_copy),
     std::move(activation_configs), std::move(gating_modes), head_bias, groups_input, groups_input_mixin,
     layer1x1_params, head1x1_params, std::move(secondary_activation_configs), film_params, film_params, film_params,
     film_params, film_params, film_params, film_params, film_params);
@@ -221,7 +221,7 @@ void test_layer_array_different_activations()
   auto film_params = make_default_film_params();
   std::vector<int> kernel_sizes(dilations.size(), kernel_size);
   nam::wavenet::LayerArrayParams params(
-    input_size, condition_size, head_size, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations),
+    input_size, condition_size, head_size, 1, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations),
     std::move(activation_configs), std::move(gating_modes), head_bias, groups, groups_input_mixin, layer1x1_params,
     head1x1_params, std::move(secondary_activation_configs), film_params, film_params, film_params, film_params,
     film_params, film_params, film_params, film_params);
@@ -304,7 +304,7 @@ void test_layer_array_different_activations()
     dilations_all_relu.size(), nam::activations::ActivationConfig{});
   std::vector<int> kernel_sizes_all_relu(dilations_all_relu.size(), kernel_size);
   nam::wavenet::LayerArrayParams params_all_relu(
-    input_size, condition_size, head_size, 1, channels, bottleneck, std::move(kernel_sizes_all_relu),
+    input_size, condition_size, head_size, 1, 1, channels, bottleneck, std::move(kernel_sizes_all_relu),
     std::move(dilations_all_relu), std::move(all_relu_configs), std::move(all_none_gating_modes), head_bias, groups,
     groups_input_mixin, layer1x1_params, head1x1_params, std::move(all_empty_secondary_configs), film_params,
     film_params, film_params, film_params, film_params, film_params, film_params, film_params);

--- a/tools/test/test_wavenet/test_layer_head_config.cpp
+++ b/tools/test/test_wavenet/test_layer_head_config.cpp
@@ -71,7 +71,7 @@ void test_nested_head_with_dilation_three()
     "layers": [{
       "input_size": 1,
       "condition_size": 1,
-      "head": {"out_channels": 1, "kernel_size": 1, "bias": true},
+      "head": {"out_channels": 1, "kernel_size": 1, "head_dilation": 3, "bias": true},
       "channels": 2,
       "kernel_size": 1,
       "dilations": [1],

--- a/tools/test/test_wavenet/test_layer_head_config.cpp
+++ b/tools/test/test_wavenet/test_layer_head_config.cpp
@@ -58,6 +58,35 @@ void test_nested_head_with_kernel_size_three()
   const auto& p = wc.layer_array_params[0];
   assert(p.head_size == 1);
   assert(p.head_kernel_size == 3);
+  assert(p.head_dilation == 1);
+  assert(p.head_bias == true);
+
+  nam::wavenet::detail::LayerArray array(p);
+  assert(array.get_receptive_field() == 2); // one dilated layer: 0 + (3-1) head rechannel
+}
+
+void test_nested_head_with_dilation_three()
+{
+  const std::string configStr = R"({
+    "layers": [{
+      "input_size": 1,
+      "condition_size": 1,
+      "head": {"out_channels": 1, "kernel_size": 1, "bias": true},
+      "channels": 2,
+      "kernel_size": 1,
+      "dilations": [1],
+      "activation": "ReLU"
+    }],
+    "head_scale": 1.0
+  })";
+
+  const nlohmann::json j = nlohmann::json::parse(configStr);
+  const auto wc = nam::wavenet::parse_config_json(j, 48000.0);
+  assert(wc.layer_array_params.size() == 1);
+  const auto& p = wc.layer_array_params[0];
+  assert(p.head_size == 1);
+  assert(p.head_kernel_size == 1);
+  assert(p.head_dilation == 3);
   assert(p.head_bias == true);
 
   nam::wavenet::detail::LayerArray array(p);

--- a/tools/test/test_wavenet/test_layer_head_config.cpp
+++ b/tools/test/test_wavenet/test_layer_head_config.cpp
@@ -71,7 +71,7 @@ void test_nested_head_with_dilation_three()
     "layers": [{
       "input_size": 1,
       "condition_size": 1,
-      "head": {"out_channels": 1, "kernel_size": 1, "head_dilation": 3, "bias": true},
+      "head": {"out_channels": 1, "kernel_size": 3, "head_dilation": 3, "bias": true},
       "channels": 2,
       "kernel_size": 1,
       "dilations": [1],

--- a/tools/test/test_wavenet/test_layer_head_config.cpp
+++ b/tools/test/test_wavenet/test_layer_head_config.cpp
@@ -85,7 +85,7 @@ void test_nested_head_with_dilation_three()
   assert(wc.layer_array_params.size() == 1);
   const auto& p = wc.layer_array_params[0];
   assert(p.head_size == 1);
-  assert(p.head_kernel_size == 1);
+  assert(p.head_kernel_size == 3);
   assert(p.head_dilation == 3);
   assert(p.head_bias == true);
 

--- a/tools/test/test_wavenet/test_layer_head_config.cpp
+++ b/tools/test/test_wavenet/test_layer_head_config.cpp
@@ -90,7 +90,7 @@ void test_nested_head_with_dilation_three()
   assert(p.head_bias == true);
 
   nam::wavenet::detail::LayerArray array(p);
-  assert(array.get_receptive_field() == 2); // one dilated layer: 0 + (3-1) head rechannel
+  assert(array.get_receptive_field() == 6); // one dilated layer: 0 + (3-1) head rechannel -- tripled because of head_dilation
 }
 
 } // namespace test_layer_head_config

--- a/tools/test/test_wavenet/test_output_head.cpp
+++ b/tools/test/test_wavenet/test_output_head.cpp
@@ -32,7 +32,7 @@ static nam::wavenet::LayerArrayParams make_layer_array_params(
   std::vector<nam::wavenet::GatingMode> gating_modes(dilations.size(), gating_mode);
   std::vector<nam::activations::ActivationConfig> secondary_activation_configs(
     dilations.size(), secondary_activation_config);
-  return nam::wavenet::LayerArrayParams(input_size, condition_size, head_size, 1, channels, bottleneck,
+  return nam::wavenet::LayerArrayParams(input_size, condition_size, head_size, 1, 1, channels, bottleneck,
                                         std::move(kernel_sizes), std::move(dilations), std::move(activation_configs),
                                         std::move(gating_modes), head_bias, groups_input, groups_input_mixin,
                                         layer1x1_params, head1x1_params, std::move(secondary_activation_configs), film,

--- a/tools/test/test_wavenet/test_real_time_safe.cpp
+++ b/tools/test/test_wavenet/test_real_time_safe.cpp
@@ -59,7 +59,7 @@ static nam::wavenet::detail::LayerArray make_layer_array(
   std::vector<int> dilations_copy = dilations; // Make a copy since we need to move it
   std::vector<int> kernel_sizes(dilations.size(), kernel_size);
   nam::wavenet::LayerArrayParams params(
-    input_size, condition_size, head_size, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations_copy),
+    input_size, condition_size, head_size, 1, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations_copy),
     std::move(activation_configs), std::move(gating_modes), head_bias, groups_input, groups_input_mixin,
     layer1x1_params, head1x1_params, std::move(secondary_activation_configs), film_params, film_params, film_params,
     film_params, film_params, film_params, film_params, film_params);
@@ -82,7 +82,7 @@ static nam::wavenet::LayerArrayParams make_layer_array_params(
   std::vector<nam::activations::ActivationConfig> secondary_activation_configs(
     dilations.size(), secondary_activation_config);
   return nam::wavenet::LayerArrayParams(
-    input_size, condition_size, head_size, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations),
+    input_size, condition_size, head_size, 1, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations),
     std::move(activation_configs), std::move(gating_modes), head_bias, groups_input, groups_input_mixin,
     layer1x1_params, head1x1_params, std::move(secondary_activation_configs), film_params, film_params, film_params,
     film_params, film_params, film_params, film_params, film_params);

--- a/tools/test/test_wavenet_configurable_gating.cpp
+++ b/tools/test/test_wavenet_configurable_gating.cpp
@@ -49,7 +49,7 @@ static nam::wavenet::LayerArrayParams make_layer_array_params(
   std::vector<nam::activations::ActivationConfig> secondary_activation_configs(
     dilations.size(), secondary_activation_config);
   return nam::wavenet::LayerArrayParams(
-    input_size, condition_size, head_size, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations),
+    input_size, condition_size, head_size, 1, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations),
     std::move(activation_configs), std::move(gating_modes), head_bias, groups_input, groups_input_mixin,
     layer1x1_params, head1x1_params, std::move(secondary_activation_configs), film_params, film_params, film_params,
     film_params, film_params, film_params, film_params, film_params);
@@ -73,7 +73,7 @@ static nam::wavenet::detail::LayerArray make_layer_array(
   std::vector<int> dilations_copy = dilations; // Make a copy since we need to move it
   std::vector<int> kernel_sizes(dilations.size(), kernel_size);
   nam::wavenet::LayerArrayParams params(
-    input_size, condition_size, head_size, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations_copy),
+    input_size, condition_size, head_size, 1, 1, channels, bottleneck, std::move(kernel_sizes), std::move(dilations_copy),
     std::move(activation_configs), std::move(gating_modes), head_bias, groups_input, groups_input_mixin,
     layer1x1_params, head1x1_params, std::move(secondary_activation_configs), film_params, film_params, film_params,
     film_params, film_params, film_params, film_params, film_params);


### PR DESCRIPTION
This adds a config variable ("head_dilation") to specify the dilation for the WaveNet layer array head.

It also adds a corresponding check for the A2 fast path.

Resolves https://github.com/sdatkinson/NeuralAmpModelerCore/issues/293