### PR TITLE
Fix A2 fast-path prewarm count to match the generic WaveNet

### DIFF
--- a/NAM/wavenet/a2_fast.cpp
+++ b/NAM/wavenet/a2_fast.cpp
@@ -172,7 +172,11 @@ A2FastModel<Channels>::A2FastModel(std::vector<float> weights, double expected_s
 
   _load_weights(weights);
 
-  int prewarm = 0;
+  // Receptive field = 1 (the sample being produced) + sum of per-layer lookbacks +
+  // (head kernel - 1). The leading 1 matches the generic WaveNet's prewarm count
+  // (model.cpp: mPrewarmSamples starts at 1 when there's no condition DSP), so the
+  // fast path warms up by exactly the same number of samples as the model it replaces.
+  int prewarm = 1;
   for (int i = 0; i < kNumLayers; i++)
     prewarm += _layers[i].max_lookback;
   prewarm += kHeadKernelSize - 1;

--- a/tools/run_tests.cpp
+++ b/tools/run_tests.cpp
@@ -353,6 +353,8 @@ int main()
   test_a2_fast::test_detector_rejects_gating();
   test_a2_fast::test_matches_generic_nano();
   test_a2_fast::test_matches_generic_standard();
+  test_a2_fast::test_prewarm_matches_generic_nano();
+  test_a2_fast::test_prewarm_matches_generic_standard();
   test_a2_fast::test_process_realtime_safe_nano();
   test_a2_fast::test_process_realtime_safe_standard();
 #endif

--- a/tools/test/test_a2_fast.cpp
+++ b/tools/test/test_a2_fast.cpp
@@ -268,6 +268,38 @@ void test_matches_generic_standard()
   test_matches_generic(8);
 }
 
+// The fast path must report the same prewarm count as the generic WaveNet it
+// replaces; otherwise Reset() warms the two by a different number of samples and
+// their first post-Reset output can diverge (regression guard for the A2 prewarm
+// off-by-one). Builds both from the identical config via the same dual path as
+// test_matches_generic.
+void test_prewarm_matches_generic(int channels)
+{
+  const auto cfg = build_a2_config(channels);
+  const int weight_count = a2_weight_count(channels);
+  const auto weights = make_deterministic_weights(weight_count, /*seed=*/0xA2FA500u + channels);
+
+  auto fast_cfg = nam::wavenet::a2_fast::create_a2_fast_config(cfg, 48000.0);
+  std::vector<float> w_fast = weights;
+  auto fast_dsp = fast_cfg->create(std::move(w_fast), 48000.0);
+
+  auto generic_cfg = nam::wavenet::parse_config_json(cfg, 48000.0);
+  std::vector<float> w_gen = weights;
+  auto generic_dsp = generic_cfg.create(std::move(w_gen), 48000.0);
+
+  assert(fast_dsp->GetPrewarmSamples() == generic_dsp->GetPrewarmSamples());
+}
+
+void test_prewarm_matches_generic_nano()
+{
+  test_prewarm_matches_generic(3);
+}
+
+void test_prewarm_matches_generic_standard()
+{
+  test_prewarm_matches_generic(8);
+}
+
 // Real-time safety: once the DSP has been Reset (buffers sized, prewarmed),
 // subsequent process() calls must not allocate or free heap memory. Uses the
 // same allocation-tracking infrastructure as the generic WaveNet RT-safety


### PR DESCRIPTION
## Summary

`A2FastModel` (the A2 fast-path WaveNet, a drop-in for the generic `WaveNet`)
computed its prewarm sample count as the layer-stack **lookback distance** —
`Σ (kernel_size-1)·dilation + (head_kernel-1)` — instead of the **receptive
field**, which is one greater. The generic path seeds `mPrewarmSamples` at `1`
(the sample being produced) before adding the same lookback terms
(`model.cpp`), so the fast path warmed up by **one fewer sample** than the
model it replaces.

## Impact

`prewarm()` runs `process()` in whole `maxBufferSize` blocks until the count is
reached, so the off-by-one only changes the block count when the total (`6346`
for the A2 shape) is an exact multiple of the buffer size. Power-of-2 buffers
(64/256/4096) mask it — which is exactly why the existing equivalence test
(`test_matches_generic`, blocks 64/256) never caught it. On a buffer size that
divides `6346` (e.g. 334), the two paths warm up by a different number of
blocks and their first post-`Reset` output diverges.

Low severity (no audible artifact at typical buffer sizes, no RT-safety
impact), but a real contract violation for a path whose whole purpose is to be
numerically identical to the generic WaveNet.

## Fix

- Seed `prewarm` at `1` to match the generic receptive-field formula, with a
  comment explaining the anchor so the count isn't re-derived incorrectly again.
- Add `test_prewarm_matches_generic_{nano,standard}`: builds both the fast and
  generic model from the same config and asserts equal `GetPrewarmSamples()`.

## Verification

Confirmed the test catches the regression — reverting the seed to `0` aborts
the new assertion; with the fix the full `run_tests` suite passes (A2 fast path
is built by default via `NAM_ENABLE_A2_FAST`).
