### PR TITLE
[FEATURE] Add NAM_NO_FILESYSTEM option for bare-metal targets

### DIFF
--- a/NAM/convnet.cpp
+++ b/NAM/convnet.cpp
@@ -1,8 +1,10 @@
 #include <algorithm> // std::max_element
 #include <algorithm>
 #include <cmath> // pow, tanh, expf
+#ifndef NAM_NO_FILESYSTEM
 #include <filesystem>
 #include <fstream>
+#endif
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/NAM/convnet.h
+++ b/NAM/convnet.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifndef NAM_NO_FILESYSTEM
 #include <filesystem>
+#endif
 #include <iterator>
 #include <memory>
 #include <string>

--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -1,8 +1,10 @@
 #include <algorithm> // std::max_element
 #include <cmath> // pow, tanh, expf
 #include <cstring>
+#ifndef NAM_NO_FILESYSTEM
 #include <filesystem>
 #include <fstream>
+#endif
 #include <stdexcept>
 #include <string>
 #include <unordered_map>

--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <atomic>
+#ifndef NAM_NO_FILESYSTEM
 #include <filesystem>
+#endif
 #include <iterator>
 #include <memory>
 #include <string>
@@ -360,12 +362,14 @@ struct dspData
 /// \param version Config version string to verify
 void verify_config_version(const std::string version);
 
+#ifndef NAM_NO_FILESYSTEM
 /// \brief Legacy loader for directory-style DSPs
 ///
 /// Loads models from a directory structure (older format).
 /// \param dirname Path to the directory containing the model
 /// \return Unique pointer to a DSP object
 std::unique_ptr<DSP> get_dsp_legacy(const std::filesystem::path dirname);
+#endif
 }; // namespace nam
 
 #include "linear.h"

--- a/NAM/get_dsp.cpp
+++ b/NAM/get_dsp.cpp
@@ -1,4 +1,6 @@
+#ifndef NAM_NO_FILESYSTEM
 #include <fstream>
+#endif
 #include <iostream>
 #include <mutex>
 #include <regex>
@@ -154,11 +156,13 @@ void populate_dsp_data(const nlohmann::json& config, dspData& returnedConfig)
   returnedConfig.expected_sample_rate = nam::get_sample_rate_from_nam_file(config);
 }
 
+#ifndef NAM_NO_FILESYSTEM
 std::unique_ptr<DSP> get_dsp(const std::filesystem::path config_filename, DspLoadOptions options)
 {
   dspData temp;
   return get_dsp(config_filename, temp, options);
 }
+#endif
 
 std::unique_ptr<DSP> get_dsp(const nlohmann::json& config, DspLoadOptions options)
 {
@@ -166,6 +170,7 @@ std::unique_ptr<DSP> get_dsp(const nlohmann::json& config, DspLoadOptions option
   return get_dsp(config, temp, options);
 }
 
+#ifndef NAM_NO_FILESYSTEM
 std::unique_ptr<DSP> get_dsp(const std::filesystem::path config_filename, dspData& returnedConfig,
                              DspLoadOptions options)
 {
@@ -184,6 +189,7 @@ std::unique_ptr<DSP> get_dsp(const std::filesystem::path config_filename, dspDat
 
   return get_dsp(conf, options);
 }
+#endif
 
 std::unique_ptr<DSP> get_dsp(const nlohmann::json& config, dspData& returnedConfig, DspLoadOptions options)
 {

--- a/NAM/get_dsp.h
+++ b/NAM/get_dsp.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifndef NAM_NO_FILESYSTEM
 #include <fstream>
+#endif
 #include <memory>
 #include <optional>
 #include <vector>
@@ -77,11 +79,13 @@ struct DspLoadOptions
   std::optional<bool> prewarm = std::nullopt;
 };
 
+#ifndef NAM_NO_FILESYSTEM
 /// \brief Get NAM from a .nam file at the provided location
 /// \param config_filename Path to the .nam model file
 /// \param options Loading options
 /// \return Unique pointer to a DSP object
 std::unique_ptr<DSP> get_dsp(const std::filesystem::path config_filename, DspLoadOptions options = DspLoadOptions());
+#endif
 
 /// \brief Get NAM from a provided configuration struct
 /// \param conf DSP data structure containing model configuration and weights
@@ -89,6 +93,7 @@ std::unique_ptr<DSP> get_dsp(const std::filesystem::path config_filename, DspLoa
 /// \return Unique pointer to a DSP object
 std::unique_ptr<DSP> get_dsp(dspData& conf, DspLoadOptions options = DspLoadOptions());
 
+#ifndef NAM_NO_FILESYSTEM
 /// \brief Get NAM from a .nam file and store its configuration
 ///
 /// Creates an instance of DSP and also returns a dspData struct that holds the data of the model.
@@ -98,6 +103,7 @@ std::unique_ptr<DSP> get_dsp(dspData& conf, DspLoadOptions options = DspLoadOpti
 /// \return Unique pointer to a DSP object
 std::unique_ptr<DSP> get_dsp(const std::filesystem::path config_filename, dspData& returnedConfig,
                              DspLoadOptions options = DspLoadOptions());
+#endif
 
 /// \brief Get NAM from a provided configuration JSON object
 /// \param config JSON configuration object


### PR DESCRIPTION
## Problem

The core cannot be linked into bare-metal firmware (Arm Cortex-M, newlib), because `NAM/dsp.h` unconditionally includes `<filesystem>` and the loaders in `get_dsp.cpp`/`dsp.cpp` reference `std::filesystem`/`std::ifstream`. libstdc++'s filesystem implementation calls POSIX syscalls that newlib does not provide, so the link fails even if the application never loads a model from a path. Minimal reproduction (Arm GNU Toolchain 15.2, `-mcpu=cortex-m7`, newlib/nosys) with a single call to `std::filesystem::exists()`:

```
ld: libstdc++.a(fs_ops.o): undefined reference to `truncate'
```

The affected targets are exactly where NAM increasingly runs: guitar pedals on MCUs (Daisy, Teensy). Embedded wrappers currently pin old core versions or carry local patches because of this; models on those targets load from embedded memory via the JSON/`dspData` entry points, never from a filesystem.

## Change

An opt-in `NAM_NO_FILESYSTEM` define guards the `<filesystem>`/`<fstream>` includes and the path-based loader entry points (the two `get_dsp(std::filesystem::path, ...)` overloads and `get_dsp_legacy`). The JSON/`dspData` entry points are untouched. Without the define, the preprocessor output is identical to main, so existing builds cannot be affected.

## Validation

- Default and `-DCMAKE_CXX_FLAGS=-DNAM_USE_INLINE_GEMM` builds: `run_tests` green (clang, Debug, same matrix as CI)
- All 13 NAM translation units compile with `-DNAM_NO_FILESYSTEM`; `nm` shows no filesystem/fstream symbols in any object
- In production use in a Teensy 4.1 (i.MX RT1062) firmware

Happy to add a CI configuration for the define if you want coverage.
