### PR TITLE
[FEATURE] Add NAM_SINGLE_THREADED option with a threading shim

### DIFF
--- a/NAM/container.cpp
+++ b/NAM/container.cpp
@@ -70,7 +70,7 @@ void ContainerModel::SetPrewarmOnReset(const bool prewarmOnReset)
 
 void ContainerModel::Reset(const double sampleRate, const int maxBufferSize)
 {
-  std::lock_guard<std::mutex> lock(_slim_set_mutex);
+  nam::LockGuard<nam::Mutex> lock(_slim_set_mutex);
 
   // Update this container's reset state without dispatching through DSP::Reset(),
   // which would prewarm the active child before the child receives these settings.
@@ -108,7 +108,7 @@ void ContainerModel::SetSlimmableSize(const double val)
 
   // Plugin host can deliver param changes from both UI/controller and processor paths.
   // Serialize reset so only one thread can perform model activation at a time.
-  std::lock_guard<std::mutex> lock(_slim_set_mutex);
+  nam::LockGuard<nam::Mutex> lock(_slim_set_mutex);
   if (active_index == _active_index.load(std::memory_order_acquire))
   {
     return;

--- a/NAM/container.h
+++ b/NAM/container.h
@@ -2,7 +2,7 @@
 
 #include <atomic>
 #include <memory>
-#include <mutex>
+#include "threading.h"
 #include <stdexcept>
 #include <vector>
 
@@ -47,7 +47,7 @@ private:
 
   std::vector<Submodel> _submodels;
   std::atomic<size_t> _active_index{0};
-  std::mutex _slim_set_mutex;
+  nam::Mutex _slim_set_mutex;
 };
 
 // Config / registration

--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -9,6 +9,7 @@
 #include <unordered_set>
 
 #include "dsp.h"
+#include "threading.h"
 #define tanh_impl_ std::tanh
 // #define tanh_impl_ fast_tanh_
 
@@ -17,7 +18,7 @@ constexpr const long _INPUT_BUFFER_SAFETY_FACTOR = 32;
 namespace
 {
 
-thread_local bool gPrewarmOnResetDefault = true;
+NAM_THREAD_LOCAL bool gPrewarmOnResetDefault = true;
 
 class ScopedDSPPrewarmOnReset
 {

--- a/NAM/get_dsp.cpp
+++ b/NAM/get_dsp.cpp
@@ -1,6 +1,6 @@
 #include <fstream>
 #include <iostream>
-#include <mutex>
+#include "threading.h"
 #include <regex>
 #include <sstream>
 #include <stdexcept>
@@ -46,9 +46,9 @@ std::vector<std::shared_ptr<const IVersionSupportChecker>>& version_support_regi
   return registry;
 }
 
-std::mutex& version_support_registry_mutex()
+nam::Mutex& version_support_registry_mutex()
 {
-  static std::mutex registry_mutex;
+  static nam::Mutex registry_mutex;
   return registry_mutex;
 }
 
@@ -94,13 +94,13 @@ void register_version_support_checker(std::shared_ptr<const IVersionSupportCheck
 {
   if (!checker)
     throw std::invalid_argument("version support checker cannot be null");
-  std::lock_guard<std::mutex> lock(version_support_registry_mutex());
+  nam::LockGuard<nam::Mutex> lock(version_support_registry_mutex());
   version_support_registry().push_back(std::move(checker));
 }
 
 Supported is_version_supported(const std::string version)
 {
-  std::lock_guard<std::mutex> lock(version_support_registry_mutex());
+  nam::LockGuard<nam::Mutex> lock(version_support_registry_mutex());
   Supported best_support = Supported::NO;
   for (const auto& checker : version_support_registry())
   {

--- a/NAM/threading.h
+++ b/NAM/threading.h
@@ -1,0 +1,44 @@
+#pragma once
+// Threading shim.
+//
+// NAM_SINGLE_THREADED: for bare-metal targets whose C library has no thread
+// support (newlib without gthreads has no std::mutex). All engine locking
+// collapses to no-ops; the embedder guarantees single-threaded use (or its
+// own external synchronization) around model loading and slim switching.
+
+// thread_local needs a TLS runtime (__aeabi_read_tp on ARM) that bare-metal
+// newlib does not provide; single-threaded builds use plain statics.
+#ifdef NAM_SINGLE_THREADED
+  #define NAM_THREAD_LOCAL
+#else
+  #define NAM_THREAD_LOCAL thread_local
+#endif
+
+#ifdef NAM_SINGLE_THREADED
+
+namespace nam
+{
+struct Mutex
+{
+};
+
+template <typename T>
+struct LockGuard
+{
+  explicit LockGuard(T&) {}
+};
+} // namespace nam
+
+#else
+
+  #include <mutex>
+
+namespace nam
+{
+using Mutex = std::mutex;
+
+template <typename T>
+using LockGuard = std::lock_guard<T>;
+} // namespace nam
+
+#endif


### PR DESCRIPTION
## Problem

Since the slimmable-container and version-registry work (#256, #260, #267, #285), the core no longer compiles for bare-metal targets (Arm Cortex-M, newlib). Two independent breakages:

1. `std::mutex` (member of `ContainerModel`, static in `get_dsp.cpp`) does not exist on newlib without gthreads; libstdc++ only defines it when `_GLIBCXX_HAS_GTHREADS` is set. Arm GNU Toolchain 15.2:

```
error: 'mutex' in namespace 'std' does not name a type
```

2. `thread_local bool gPrewarmOnResetDefault` (dsp.cpp) emits a reference to the TLS runtime, which bare metal does not provide:

```
undefined reference to `__aeabi_read_tp'
```

Before those changes the core built fine on these targets, so embedded users are effectively pinned to pre-0.7.x cores and locked out of the SlimmableContainer/A2 features.

## Change

A new `NAM/threading.h` routes the three primitives through `nam::Mutex`, `nam::LockGuard`, and `NAM_THREAD_LOCAL`. By default these alias `std::mutex`, `std::lock_guard`, and `thread_local` — zero change for every existing build. With `NAM_SINGLE_THREADED` defined, locking collapses to no-ops and `NAM_THREAD_LOCAL` to a plain static: on a single-threaded MCU there is nothing to synchronize, and the embedder takes responsibility for external synchronization if it does run threads. `std::atomic` is deliberately untouched (newlib supports it, and the lock-free container index should stay atomic).

## Validation

- Default and inline-GEMM builds: `run_tests` green (same matrix as CI)
- Full tools build with `-DNAM_SINGLE_THREADED` on desktop: compiles and `run_tests` green (the shim is semantically neutral in a single-threaded process)
- In production use in a Teensy 4.1 (i.MX RT1062) firmware
