### PR TITLE
Remove a per-call allocation and two redundant copies from the hot path

### DIFF
--- a/NAM/activations.h
+++ b/NAM/activations.h
@@ -302,9 +302,6 @@ public:
     // Matrix is organized as (channels, time_steps)
     unsigned long actual_channels = static_cast<unsigned long>(matrix.rows());
 
-    // Prepare the slopes for the current matrix size
-    std::vector<float> slopes_for_channels = negative_slopes;
-
     // Fail loudly if input has more channels than activation
 #ifndef NDEBUG
     if (actual_channels != negative_slopes.size())
@@ -321,7 +318,7 @@ public:
       // Apply the negative slope to all time steps in this channel
       for (int time_step = 0; time_step < matrix.cols(); time_step++)
       {
-        matrix(channel, time_step) = leaky_relu(matrix(channel, time_step), slopes_for_channels[channel]);
+        matrix(channel, time_step) = leaky_relu(matrix(channel, time_step), negative_slopes[channel]);
       }
     }
   }

--- a/NAM/wavenet/model.cpp
+++ b/NAM/wavenet/model.cpp
@@ -427,8 +427,10 @@ long nam::wavenet::detail::LayerArray::get_receptive_field() const
 void nam::wavenet::detail::LayerArray::Process(const Eigen::MatrixXf& layer_inputs, const Eigen::MatrixXf& condition,
                                                const int num_frames)
 {
-  // Zero head inputs accumulator (first layer array)
-  this->_head_inputs.setZero();
+  // Zero head inputs accumulator (first layer array). Only the first num_frames columns are ever
+  // read this call, so zeroing the whole maxBufferSize-wide buffer is wasted work when the host
+  // processes blocks smaller than the maximum it reserved.
+  this->_head_inputs.leftCols(num_frames).setZero();
   ProcessInner(layer_inputs, condition, num_frames);
 }
 
@@ -776,12 +778,12 @@ void nam::wavenet::WaveNet::process(NAM_SAMPLE** input, NAM_SAMPLE** output, con
   if (this->_post_stack_head != nullptr)
   {
     assert(final_head_outputs.rows() == this->_post_stack_head->in_channels());
-    const int head_in = this->_post_stack_head->in_channels();
-    for (int ch = 0; ch < head_in; ch++)
-    {
-      for (int s = 0; s < num_frames; s++)
-        this->_scaled_head_scratch(ch, s) = this->_head_scale * final_head_outputs(ch, s);
-    }
+    // _scaled_head_scratch is sized (in_channels, maxBufferSize), and the assert above pins
+    // final_head_outputs to the same row count, so this is a straight scaled copy of the block.
+    // Expressed as one Eigen expression rather than a nested loop: the manual loop walked the
+    // column-major matrix with a row-major access pattern, striding by in_channels per step.
+    this->_scaled_head_scratch.leftCols(num_frames).noalias() =
+      this->_head_scale * final_head_outputs.leftCols(num_frames);
     this->_post_stack_head->process(this->_scaled_head_scratch, num_frames);
     const Eigen::MatrixXf& head_out = this->_post_stack_head->get_last_output();
     assert(head_out.rows() == out_channels);

--- a/tools/run_tests.cpp
+++ b/tools/run_tests.cpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include "test/test_activations.cpp"
+#include "test/test_activations_realtime_safe.cpp"
 #include "test/test_conv1d.cpp"
 #include "test/test_conv_1x1.cpp"
 #include "test/test_convnet.cpp"
@@ -62,6 +63,9 @@ int main()
   test_activations::TestPReLU::test_wrong_number_of_channels_matrix();
   test_activations::TestPReLU::test_wrong_size_array();
   test_activations::TestPReLU::test_valid_array_size();
+
+  test_activations_realtime_safe::test_prelu_apply_matrix_realtime_safe();
+  test_activations_realtime_safe::test_prelu_apply_pointer_realtime_safe();
 
   // Typed ActivationConfig tests
   test_activations::TestTypedActivationConfig::test_simple_config();

--- a/tools/test/test_activations_realtime_safe.cpp
+++ b/tools/test/test_activations_realtime_safe.cpp
@@ -1,0 +1,65 @@
+// Test to verify activation apply() overloads are real-time safe (no allocations/frees)
+
+#include <Eigen/Dense>
+#include <cassert>
+#include <cmath>
+#include <vector>
+
+#include "NAM/activations.h"
+#include "allocation_tracking.h"
+
+namespace test_activations_realtime_safe
+{
+using namespace allocation_tracking;
+
+// PReLU's matrix overload is reached once per sample from the gating/blending activations, so a
+// heap allocation here lands directly on the audio thread.
+void test_prelu_apply_matrix_realtime_safe()
+{
+  const int channels = 8;
+  const int time_steps = 64;
+
+  std::vector<float> slopes;
+  for (int i = 0; i < channels; i++)
+    slopes.push_back(0.01f * static_cast<float>(i + 1));
+
+  nam::activations::ActivationPReLU activation(slopes);
+
+  Eigen::MatrixXf matrix(channels, time_steps);
+  matrix.setConstant(-1.0f);
+
+  run_allocation_test_no_allocations(
+    nullptr, // No setup needed
+    [&]() { activation.apply(matrix); }, nullptr, // No teardown needed
+    "test_prelu_apply_matrix_realtime_safe");
+
+  // Each channel should have been scaled by its own slope.
+  for (int c = 0; c < channels; c++)
+    assert(std::abs(matrix(c, 0) - (-slopes[c])) < 1e-6f);
+}
+
+// The pointer/length overload is the one used by the plain (non-gated) path.
+void test_prelu_apply_pointer_realtime_safe()
+{
+  const int channels = 4;
+  const int time_steps = 32;
+
+  std::vector<float> slopes;
+  for (int i = 0; i < channels; i++)
+    slopes.push_back(0.05f * static_cast<float>(i + 1));
+
+  nam::activations::ActivationPReLU activation(slopes);
+
+  Eigen::MatrixXf matrix(channels, time_steps);
+  matrix.setConstant(-2.0f);
+
+  run_allocation_test_no_allocations(
+    nullptr, // No setup needed
+    [&]() { activation.apply(matrix.data(), static_cast<long>(channels) * time_steps); },
+    nullptr, // No teardown needed
+    "test_prelu_apply_pointer_realtime_safe");
+
+  for (int c = 0; c < channels; c++)
+    assert(std::abs(matrix(c, 0) - (-2.0f * slopes[c])) < 1e-6f);
+}
+} // namespace test_activations_realtime_safe


### PR DESCRIPTION
Three independent inefficiencies on the audio thread. No behaviour change — same outputs, same weights, less work per block.

### 1. PReLU allocated on the audio thread

`ActivationPReLU::apply(Eigen::MatrixXf&)` copied its whole `negative_slopes` vector into a local on every call:

```cpp
std::vector<float> slopes_for_channels = negative_slopes;  // never mutated
```

That overload is reached **once per sample** from `GatingActivation::apply` / `BlendingActivation::apply` whenever a layer uses `gating_mode: gated`/`blended` with PReLU — so it was a heap allocation on the audio thread, which is exactly what the rest of this code goes out of its way to avoid (`lstm.h:29-31`, `dsp.h:315-321`, the `noalias()` discipline in `wavenet/model.cpp`). The copy was read-only, so indexing `negative_slopes` directly is equivalent.

### 2. Zeroing a buffer wider than the block being processed

`LayerArray::Process` did `_head_inputs.setZero()` on the full `(head_output_size × maxBufferSize)` accumulator every block. Only the first `num_frames` columns are ever read, so a host that reserves for its worst case (say 4096) and then processes 64–512 frames was zeroing memory nothing looks at, every block.

Now `leftCols(num_frames).setZero()`. I traced every consumer before changing this, since previously the tail could never hold stale data and now it can:

- `model.cpp:442` / `:479` (`NAM_USE_INLINE_GEMM`) — `memcpy`/raw-pointer writes bounded by `head_output_size * num_frames`. Eigen is column-major, so that byte range **is** `leftCols(num_frames)`.
- `model.cpp:445`, `:492` — explicitly `.leftCols(num_frames)`.
- `model.cpp:510` — `_head_rechannel.Process(_head_inputs, num_frames)` → `Conv1D::Process` reads the input only via `RingBuffer::Write`, which slices `leftCols(num_frames)` (`ring_buffer.cpp:41`).

Nothing reads past `num_frames` on any branch, including both GEMM variants.

### 3. Row-major access over a column-major matrix

The post-stack head's scaling step was a nested `for (ch) for (s)` loop, so the inner loop strided by `in_channels` floats per step through a column-major matrix. It's just a scaled copy of a contiguous block:

```cpp
_scaled_head_scratch.leftCols(num_frames).noalias() = _head_scale * final_head_outputs.leftCols(num_frames);
```

`_scaled_head_scratch` is sized `(in_channels, maxBufferSize)` and the pre-existing `assert` above pins `final_head_outputs` to the same row count. The two are distinct members, so `noalias()` is sound.

### Test

`tools/test/test_activations_realtime_safe.cpp` uses the allocation tracker already in the suite (same shape as `test_film_realtime_safe.cpp`) to pin the PReLU fix, covering both `apply` overloads. Restoring the old copy verbatim makes it fail with **2 allocations instead of 0**, so it genuinely guards the change rather than passing incidentally.

### Verification

Built and tested with clang 18 under `-Werror` across **Debug, Release, and `NAM_USE_INLINE_GEMM=ON`** — `run_tests` exits 0 on all three. `clang-format` 19 clean on the changed files.

### Note

`clang-format` also wants to reflow the `LayerArrayParams(...)` call at `model.cpp:1153` (a pre-existing line over the 120-column limit on `main`, unrelated to this change). I reverted that hunk to keep this diff to just the three fixes — happy to include it, or fix it separately, if you'd prefer.

I haven't attached benchmark numbers; the gains are structural (one fewer allocation per call; zeroing and copying proportional to the block rather than the reservation) and their size depends on the host's `maxBufferSize`-to-block-size ratio. Glad to measure with `bench_a2_fast` if useful.
