### PR TITLE
Adding flexibility for embedded devices. Optimizing A2 by ~1.5%

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	add_compile_definitions(NOMINMAX WIN32_LEAN_AND_MEAN)
+	add_compile_definitions(_USE_MATH_DEFINES)
 else()
 	message(FATAL_ERROR "Unrecognized Platform!")
 endif()
@@ -62,9 +63,13 @@ endif()
 
 add_subdirectory(tools)
 
-#file(MAKE_DIRECTORY build/tools)
-
-#add_custom_target(copy_tools ALL
-#	${CMAKE_COMMAND} -E copy "$<TARGET_FILE:tools>" tools/
-#	DEPENDS tools
-#)
+# Copy example assets after build
+add_custom_target(copy_tools ALL
+	COMMAND ${CMAKE_COMMAND} -E copy_directory
+	"${CMAKE_CURRENT_SOURCE_DIR}/example_models"
+	"${CMAKE_CURRENT_BINARY_DIR}/tools/example_models"
+	COMMAND ${CMAKE_COMMAND} -E copy_directory
+	"${CMAKE_CURRENT_SOURCE_DIR}/example_audio"
+	"${CMAKE_CURRENT_BINARY_DIR}/tools/example_audio"
+	DEPENDS tools
+)

--- a/NAM/activations.cpp
+++ b/NAM/activations.cpp
@@ -56,6 +56,7 @@ nam::activations::ActivationConfig nam::activations::ActivationConfig::simple(Ac
   return config;
 }
 
+#if NAM_HAS_JSON
 nam::activations::ActivationConfig nam::activations::ActivationConfig::from_json(const nlohmann::json& j)
 {
   ActivationConfig config;
@@ -82,7 +83,7 @@ nam::activations::ActivationConfig nam::activations::ActivationConfig::from_json
     auto it = type_map.find(name);
     if (it == type_map.end())
     {
-      throw std::runtime_error("Unknown activation type: " + name);
+      NAM_THROW(std::runtime_error("Unknown activation type: " + name));
     }
     config.type = it->second;
     return config;
@@ -95,7 +96,7 @@ nam::activations::ActivationConfig nam::activations::ActivationConfig::from_json
     auto it = type_map.find(type_str);
     if (it == type_map.end())
     {
-      throw std::runtime_error("Unknown activation type: " + type_str);
+      NAM_THROW(std::runtime_error("Unknown activation type: " + type_str));
     }
     config.type = it->second;
 
@@ -126,8 +127,9 @@ nam::activations::ActivationConfig nam::activations::ActivationConfig::from_json
     return config;
   }
 
-  throw std::runtime_error("Invalid activation config: expected string or object");
+  NAM_THROW(std::runtime_error("Invalid activation config: expected string or object"));
 }
+#endif // NAM_HAS_JSON
 
 nam::activations::Activation::Ptr nam::activations::Activation::get_activation(const ActivationConfig& config)
 {
@@ -206,7 +208,7 @@ void nam::activations::Activation::enable_lut(std::string function_name, float m
   }
   else
   {
-    throw std::runtime_error("Tried to enable LUT for a function other than Tanh, Sigmoid, or SiLU");
+    NAM_THROW(std::runtime_error("Tried to enable LUT for a function other than Tanh, Sigmoid, or SiLU"));
   }
   _activations[function_name] = std::make_shared<FastLUTActivation>(min, max, n_points, fn);
 }
@@ -227,6 +229,6 @@ void nam::activations::Activation::disable_lut(std::string function_name)
   }
   else
   {
-    throw std::runtime_error("Tried to disable LUT for a function other than Tanh, Sigmoid, or SiLU");
+    NAM_THROW(std::runtime_error("Tried to disable LUT for a function other than Tanh, Sigmoid, or SiLU"));
   }
 }

--- a/NAM/activations.h
+++ b/NAM/activations.h
@@ -2,18 +2,18 @@
 
 #include <cassert>
 #include <cmath> // expf
-#include <iostream> // std::cerr (kept for potential debug use)
-#include <stdexcept> // std::invalid_argument
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
+#include "compiler.h"
 #include <Eigen/Dense>
 
-#include "json.hpp"
+#if NAM_HAS_JSON
+  #include "json.hpp"
+#endif
 
 namespace nam
 {
@@ -54,7 +54,9 @@ struct ActivationConfig
 
   // Convenience constructors
   static ActivationConfig simple(ActivationType t);
+#if NAM_HAS_JSON
   static ActivationConfig from_json(const nlohmann::json& j);
+#endif
 };
 inline float relu(float x)
 {
@@ -159,7 +161,9 @@ public:
 
   static Ptr get_activation(const std::string name);
   static Ptr get_activation(const ActivationConfig& config);
+#if NAM_HAS_JSON
   static Ptr get_activation(const nlohmann::json& activation_config);
+#endif
   static void enable_fast_tanh();
   static void disable_fast_tanh();
   static bool using_fast_tanh;
@@ -285,9 +289,9 @@ public:
 #ifndef NDEBUG
     if (size % negative_slopes.size() != 0)
     {
-      throw std::invalid_argument("PReLU.apply(*data, size) was given an array of size " + std::to_string(size)
+      NAM_THROW(std::invalid_argument("PReLU.apply(*data, size) was given an array of size " + std::to_string(size)
                                   + " but the activation has " + std::to_string(negative_slopes.size())
-                                  + " channels, which doesn't divide evenly.");
+                                  + " channels, which doesn't divide evenly."));
     }
 #endif
     for (long pos = 0; pos < size; pos++)
@@ -309,9 +313,9 @@ public:
 #ifndef NDEBUG
     if (actual_channels != negative_slopes.size())
     {
-      throw std::invalid_argument("PReLU: Received " + std::to_string(actual_channels)
+      NAM_THROW(std::invalid_argument("PReLU: Received " + std::to_string(actual_channels)
                                   + " channels, but activation has " + std::to_string(negative_slopes.size())
-                                  + " channels");
+                                  + " channels"));
     }
 #endif
 

--- a/NAM/compiler.h
+++ b/NAM/compiler.h
@@ -1,7 +1,78 @@
 #pragma once
 
+// Portability layer. Everything that differs between a desktop plugin build and
+// a constrained embedded build is decided here, so the rest of the library can be
+// written as plain C++ without conditional compilation at the call sites.
+//
+// Opt-in switches, defined on the compiler command line:
+//   NAM_NO_EXCEPTIONS  target is built with -fno-exceptions
+//   NAM_NO_MUTEX       target is single threaded
+//   NAM_NO_JSON        drop the JSON (.nam) loader; binary (.namb) loading only
+//   NAM_NO_FILESYSTEM  target has no std::filesystem; drop path-based loading
+
+#include <cstdlib>
+
+#if !defined(NAM_NO_EXCEPTIONS)
+  #include <stdexcept>
+#endif
+
+#if !defined(NAM_NO_MUTEX)
+  #include <mutex>
+#endif
+
 #if defined(_MSC_VER) && !defined(__llvm__)
   #define NAM_RESTRICT __restrict
 #else
   #define NAM_RESTRICT __restrict__
+#endif
+
+#if defined(NAM_NO_JSON)
+  #define NAM_HAS_JSON 0
+#else
+  #define NAM_HAS_JSON 1
+#endif
+
+#if defined(NAM_NO_FILESYSTEM)
+  #define NAM_HAS_FILESYSTEM 0
+#else
+  #define NAM_HAS_FILESYSTEM 1
+#endif
+
+namespace nam
+{
+namespace detail
+{
+/// \brief Terminal error handler used when exceptions are disabled
+/// \param what Stringified exception expression; never evaluated, so failure paths
+///             cost no code and perform no allocation
+[[noreturn]] inline void fail(const char* what)
+{
+  (void)what;
+  std::abort();
+}
+} // namespace detail
+
+#if defined(NAM_NO_MUTEX)
+class Mutex
+{
+public:
+  void lock() {}
+  void unlock() {}
+};
+
+class LockGuard
+{
+public:
+  explicit LockGuard(Mutex&) {}
+};
+#else
+using Mutex = std::mutex;
+using LockGuard = std::lock_guard<std::mutex>;
+#endif
+} // namespace nam
+
+#if defined(NAM_NO_EXCEPTIONS)
+  #define NAM_THROW(...) ::nam::detail::fail(#__VA_ARGS__)
+#else
+  #define NAM_THROW(...) throw __VA_ARGS__
 #endif

--- a/NAM/compiler.h
+++ b/NAM/compiler.h
@@ -38,6 +38,11 @@
   #define NAM_HAS_FILESYSTEM 1
 #endif
 
+#ifndef NAM_SECTION_CODE_FAST
+  // Intentionally empty by default; target builds may place hot code in fast memory.
+  #define NAM_SECTION_CODE_FAST
+#endif
+
 namespace nam
 {
 namespace detail

--- a/NAM/container.cpp
+++ b/NAM/container.cpp
@@ -21,16 +21,16 @@ ContainerModel::ContainerModel(std::vector<Submodel> submodels, const double exp
 , _submodels(std::move(submodels))
 {
   if (_submodels.empty())
-    throw std::runtime_error("ContainerModel: no submodels provided");
+    NAM_THROW(std::runtime_error("ContainerModel: no submodels provided"));
 
   // Validate ordering and that final max_value covers 1.0
   for (size_t i = 1; i < _submodels.size(); ++i)
   {
     if (_submodels[i].max_value <= _submodels[i - 1].max_value)
-      throw std::runtime_error("ContainerModel: submodels must be sorted by ascending max_value");
+      NAM_THROW(std::runtime_error("ContainerModel: submodels must be sorted by ascending max_value"));
   }
   if (_submodels.back().max_value < 1.0)
-    throw std::runtime_error("ContainerModel: last submodel max_value must be >= 1.0");
+    NAM_THROW(std::runtime_error("ContainerModel: last submodel max_value must be >= 1.0"));
 
   // Validate all submodels have the same expected sample rate
   for (const auto& sm : _submodels)
@@ -41,7 +41,7 @@ ContainerModel::ContainerModel(std::vector<Submodel> submodels, const double exp
     {
       std::stringstream ss;
       ss << "ContainerModel: submodel sample rate mismatch (expected " << expected_sample_rate << ", got " << sr << ")";
-      throw std::runtime_error(ss.str());
+      NAM_THROW(std::runtime_error(ss.str()));
     }
   }
 
@@ -149,7 +149,7 @@ std::unique_ptr<DSP> ContainerConfig::create(std::vector<float> weights, double 
 
   auto submodels_json = raw_config["submodels"];
   if (!submodels_json.is_array() || submodels_json.empty())
-    throw std::runtime_error("SlimmableContainer: 'submodels' must be a non-empty array");
+    NAM_THROW(std::runtime_error("SlimmableContainer: 'submodels' must be a non-empty array"));
 
   std::vector<Submodel> submodels;
   submodels.reserve(submodels_json.size());

--- a/NAM/conv1d.cpp
+++ b/NAM/conv1d.cpp
@@ -1,7 +1,6 @@
 #include "conv1d.h"
 #include "compiler.h"
 #include <cstring>
-#include <stdexcept>
 
 namespace nam
 {
@@ -59,13 +58,13 @@ void Conv1D::set_size_(const int in_channels, const int out_channels, const int 
   // Validate that channels divide evenly by groups
   if (in_channels % groups != 0)
   {
-    throw std::runtime_error("in_channels (" + std::to_string(in_channels) + ") must be divisible by numGroups ("
-                             + std::to_string(groups) + ")");
+    NAM_THROW(std::runtime_error("in_channels (" + std::to_string(in_channels) + ") must be divisible by numGroups ("
+                             + std::to_string(groups) + ")"));
   }
   if (out_channels % groups != 0)
   {
-    throw std::runtime_error("out_channels (" + std::to_string(out_channels) + ") must be divisible by numGroups ("
-                             + std::to_string(groups) + ")");
+    NAM_THROW(std::runtime_error("out_channels (" + std::to_string(out_channels) + ") must be divisible by numGroups ("
+                             + std::to_string(groups) + ")"));
   }
 
   this->_num_groups = groups;

--- a/NAM/convnet.cpp
+++ b/NAM/convnet.cpp
@@ -195,7 +195,7 @@ nam::convnet::ConvNet::ConvNet(const int in_channels, const int out_channels, co
   this->_head = _Head(channels, out_channels, it);
 
   if (it != weights.end())
-    throw std::runtime_error("Didn't touch all the weights when initializing ConvNet");
+    NAM_THROW(std::runtime_error("Didn't touch all the weights when initializing ConvNet"));
 
   mPrewarmSamples = 1;
   for (size_t i = 0; i < dilations.size(); i++)
@@ -323,6 +323,7 @@ void nam::convnet::ConvNet::_rewind_buffers_()
 }
 
 // Config parser
+#if NAM_HAS_JSON
 nam::convnet::ConvNetConfig nam::convnet::parse_config_json(const nlohmann::json& config)
 {
   ConvNetConfig c;
@@ -337,6 +338,7 @@ nam::convnet::ConvNetConfig nam::convnet::parse_config_json(const nlohmann::json
   c.out_channels = config.value("out_channels", 1);
   return c;
 }
+#endif
 
 // ConvNetConfig::create()
 std::unique_ptr<nam::DSP> nam::convnet::ConvNetConfig::create(std::vector<float> weights, double sampleRate)
@@ -346,6 +348,7 @@ std::unique_ptr<nam::DSP> nam::convnet::ConvNetConfig::create(std::vector<float>
 }
 
 // Config parser for ConfigParserRegistry
+#if NAM_HAS_JSON
 std::unique_ptr<nam::ModelConfig> nam::convnet::create_config(const nlohmann::json& config, double sampleRate)
 {
   (void)sampleRate;
@@ -359,3 +362,4 @@ namespace
 {
 static nam::ConfigParserHelper _register_ConvNet("ConvNet", nam::convnet::create_config);
 }
+#endif // NAM_HAS_JSON

--- a/NAM/convnet.h
+++ b/NAM/convnet.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <filesystem>
 #include <iterator>
 #include <memory>
 #include <string>
@@ -12,7 +11,11 @@
 #include "activations.h"
 #include "conv1d.h"
 #include "dsp.h"
-#include "json.hpp"
+
+#if NAM_HAS_JSON
+  #include <filesystem>
+  #include "json.hpp"
+#endif
 
 namespace nam
 {
@@ -180,6 +183,7 @@ struct ConvNetConfig : public ModelConfig
   std::unique_ptr<DSP> create(std::vector<float> weights, double sampleRate) override;
 };
 
+#if NAM_HAS_JSON
 /// \brief Parse ConvNet configuration from JSON
 /// \param config JSON configuration object
 /// \return ConvNetConfig
@@ -187,6 +191,7 @@ ConvNetConfig parse_config_json(const nlohmann::json& config);
 
 /// \brief Config parser for ConfigParserRegistry
 std::unique_ptr<ModelConfig> create_config(const nlohmann::json& config, double sampleRate);
+#endif
 
 }; // namespace convnet
 }; // namespace nam

--- a/NAM/dsp.cpp
+++ b/NAM/dsp.cpp
@@ -3,11 +3,11 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
-#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 
+#include "compiler.h"
 #include "dsp.h"
 #define tanh_impl_ std::tanh
 // #define tanh_impl_ fast_tanh_
@@ -60,7 +60,7 @@ nam::DSP::DSP(const int in_channels, const int out_channels, const double expect
 {
   if (in_channels <= 0 || out_channels <= 0)
   {
-    throw std::runtime_error("Channel counts must be positive");
+    NAM_THROW(std::runtime_error("Channel counts must be positive"));
   }
 }
 
@@ -122,7 +122,7 @@ double nam::DSP::GetLoudness() const
 {
   if (!HasLoudness())
   {
-    throw std::runtime_error("Asked for loudness of a model that doesn't know how loud it is!");
+    NAM_THROW(std::runtime_error("Asked for loudness of a model that doesn't know how loud it is!"));
   }
   return mLoudness;
 }
@@ -313,13 +313,13 @@ nam::Conv1x1::Conv1x1(const int in_channels, const int out_channels, const bool 
   // Validate that channels divide evenly by groups
   if (in_channels % groups != 0)
   {
-    throw std::runtime_error("in_channels (" + std::to_string(in_channels) + ") must be divisible by numGroups ("
-                             + std::to_string(groups) + ")");
+    NAM_THROW(std::runtime_error("in_channels (" + std::to_string(in_channels) + ") must be divisible by numGroups ("
+                             + std::to_string(groups) + ")"));
   }
   if (out_channels % groups != 0)
   {
-    throw std::runtime_error("out_channels (" + std::to_string(out_channels) + ") must be divisible by numGroups ("
-                             + std::to_string(groups) + ")");
+    NAM_THROW(std::runtime_error("out_channels (" + std::to_string(out_channels) + ") must be divisible by numGroups ("
+                             + std::to_string(groups) + ")"));
   }
 
   this->_num_groups = groups;

--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -76,9 +76,6 @@ private:
 class DSP
 {
 public:
-  using LayerObserver = void (*)(void* context, size_t layerArrayIndex,
-                                 size_t layerIndex, bool starting);
-
   /// \brief Constructor
   ///
   /// \param in_channels Number of input channels
@@ -109,7 +106,6 @@ public:
   ///
   /// A virtual query rather than a dynamic_cast, so callers work without RTTI.
   virtual SlimmableModel* GetSlimmableModel() { return nullptr; }
-  virtual void SetLayerObserver(LayerObserver observer, void* context) {}
   /// \brief Get the expected sample rate
   /// \return Expected sample rate in Hz (-1.0 if unknown)
   double GetExpectedSampleRate() const { return mExpectedSampleRate; };

--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <filesystem>
 #include <iterator>
 #include <memory>
 #include <string>
@@ -12,8 +11,12 @@
 
 #include "activations.h"
 #include "compiler.h"
-#include "json.hpp"
 #include "model_config.h"
+
+#if NAM_HAS_JSON
+  #include <filesystem>
+  #include "json.hpp"
+#endif
 
 #ifdef NAM_SAMPLE_FLOAT
   #define NAM_SAMPLE float
@@ -31,6 +34,8 @@
 
 namespace nam
 {
+class SlimmableModel;
+
 namespace wavenet
 {
 /// Forward declaration to allow WaveNet to access protected members of DSP
@@ -95,6 +100,11 @@ public:
   /// \param output Output audio buffers. Same structure as input.
   /// \param num_frames Number of frames to process
   virtual void process(NAM_SAMPLE** input, NAM_SAMPLE** output, const int num_frames);
+
+  /// \brief Slimmable interface of this model, or nullptr if it cannot be slimmed
+  ///
+  /// A virtual query rather than a dynamic_cast, so callers work without RTTI.
+  virtual SlimmableModel* GetSlimmableModel() { return nullptr; }
   /// \brief Get the expected sample rate
   /// \return Expected sample rate in Hz (-1.0 if unknown)
   double GetExpectedSampleRate() const { return mExpectedSampleRate; };
@@ -342,6 +352,7 @@ private:
 // Utilities ==================================================================
 // Implemented in get_dsp.cpp
 
+#if NAM_HAS_JSON
 /// \brief Data structure for a DSP object
 ///
 /// Contains all information needed to instantiate and configure a DSP model.
@@ -355,17 +366,20 @@ struct dspData
   double expected_sample_rate; ///< Expected sample rate in Hz. Most NAM models implicitly assume data at some sample
                                ///< rate. Use -1.0 for "I don't know".
 };
+#endif
 
 /// \brief Verify that the config version is supported by this plugin version
 /// \param version Config version string to verify
 void verify_config_version(const std::string version);
 
+#if NAM_HAS_JSON
 /// \brief Legacy loader for directory-style DSPs
 ///
 /// Loads models from a directory structure (older format).
 /// \param dirname Path to the directory containing the model
 /// \return Unique pointer to a DSP object
 std::unique_ptr<DSP> get_dsp_legacy(const std::filesystem::path dirname);
+#endif
 }; // namespace nam
 
 #include "linear.h"

--- a/NAM/dsp.h
+++ b/NAM/dsp.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
 #include <iterator>
 #include <memory>
 #include <string>
@@ -75,6 +76,9 @@ private:
 class DSP
 {
 public:
+  using LayerObserver = void (*)(void* context, size_t layerArrayIndex,
+                                 size_t layerIndex, bool starting);
+
   /// \brief Constructor
   ///
   /// \param in_channels Number of input channels
@@ -105,6 +109,7 @@ public:
   ///
   /// A virtual query rather than a dynamic_cast, so callers work without RTTI.
   virtual SlimmableModel* GetSlimmableModel() { return nullptr; }
+  virtual void SetLayerObserver(LayerObserver observer, void* context) {}
   /// \brief Get the expected sample rate
   /// \return Expected sample rate in Hz (-1.0 if unknown)
   double GetExpectedSampleRate() const { return mExpectedSampleRate; };

--- a/NAM/gating_activations.h
+++ b/NAM/gating_activations.h
@@ -5,7 +5,6 @@
 #include <unordered_map>
 #include <Eigen/Dense>
 #include <functional>
-#include <stdexcept>
 #include "activations.h"
 #include "compiler.h"
 
@@ -41,7 +40,7 @@ public:
   {
     if (num_channels <= 0)
     {
-      throw std::invalid_argument("GatingActivation: number of input channels must be positive");
+      NAM_THROW(std::invalid_argument("GatingActivation: number of input channels must be positive"));
     }
     // Initialize buffers with correct size
     // Note: current code copies column-by-column so we only need (num_channels, 1)

--- a/NAM/get_dsp.cpp
+++ b/NAM/get_dsp.cpp
@@ -1,31 +1,61 @@
-#include <fstream>
-#include <iostream>
-#include <mutex>
-#include <regex>
-#include <sstream>
-#include <stdexcept>
-
+#include "compiler.h"
 #include "dsp.h"
-#include "registry.h"
-#include "json.hpp"
 #include "get_dsp.h"
 #include "model_config.h"
+
+#if NAM_HAS_JSON
+  #include <fstream>
+  #include "json.hpp"
+  #include "registry.h"
+#endif
 
 namespace nam
 {
 namespace
 {
 
+/// Parses "major.minor.patch" without exceptions or <regex>.
+bool try_parse_version(const std::string& versionStr, Version& parsed)
+{
+  int components[3] = {0, 0, 0};
+  size_t pos = 0;
+  for (int i = 0; i < 3; i++)
+  {
+    if (i > 0)
+    {
+      if (pos >= versionStr.size() || versionStr[pos] != '.')
+        return false;
+      pos++;
+    }
+    const size_t start = pos;
+    int value = 0;
+    while (pos < versionStr.size() && versionStr[pos] >= '0' && versionStr[pos] <= '9')
+    {
+      if (value > 100000)
+        return false;
+      value = value * 10 + (versionStr[pos] - '0');
+      pos++;
+    }
+    if (pos == start)
+      return false;
+    components[i] = value;
+  }
+  if (pos != versionStr.size())
+    return false;
+
+  parsed = Version(components[0], components[1], components[2]);
+  return true;
+}
+
 class CoreVersionSupportChecker : public IVersionSupportChecker
 {
 public:
   Supported support(const std::string& version) const override
   {
-    static const std::regex semver_regex(R"(^\d+\.\d+\.\d+$)");
-    if (!std::regex_match(version, semver_regex))
+    Version parsed(0, 0, 0);
+    if (!try_parse_version(version, parsed))
       return Supported::NO;
 
-    const Version parsed = ParseVersion(version);
     const Version latest = ParseVersion(LATEST_FULLY_SUPPORTED_NAM_FILE_VERSION);
     const Version earliest = ParseVersion(EARLIEST_SUPPORTED_NAM_FILE_VERSION);
 
@@ -46,9 +76,9 @@ std::vector<std::shared_ptr<const IVersionSupportChecker>>& version_support_regi
   return registry;
 }
 
-std::mutex& version_support_registry_mutex()
+Mutex& version_support_registry_mutex()
 {
-  static std::mutex registry_mutex;
+  static Mutex registry_mutex;
   return registry_mutex;
 }
 
@@ -56,51 +86,23 @@ std::mutex& version_support_registry_mutex()
 
 Version ParseVersion(const std::string& versionStr)
 {
-  // Split the version string into major, minor, and patch components
-  std::stringstream ss(versionStr);
-  std::string majorStr, minorStr, patchStr;
-  std::getline(ss, majorStr, '.');
-  std::getline(ss, minorStr, '.');
-  std::getline(ss, patchStr);
-
-  // Parse the components as integers and assign them to the version struct
-  int major;
-  int minor;
-  int patch;
-  try
-  {
-    major = std::stoi(majorStr);
-    minor = std::stoi(minorStr);
-    patch = std::stoi(patchStr);
-  }
-  catch (const std::invalid_argument&)
-  {
-    throw std::invalid_argument("Invalid version string: " + versionStr);
-  }
-  catch (const std::out_of_range&)
-  {
-    throw std::out_of_range("Version string out of range: " + versionStr);
-  }
-
-  // Validate the semver components
-  if (major < 0 || minor < 0 || patch < 0)
-  {
-    throw std::invalid_argument("Negative version component: " + versionStr);
-  }
-  return Version(major, minor, patch);
+  Version parsed(0, 0, 0);
+  if (!try_parse_version(versionStr, parsed))
+    NAM_THROW(std::invalid_argument("Invalid version string: " + versionStr));
+  return parsed;
 }
 
 void register_version_support_checker(std::shared_ptr<const IVersionSupportChecker> checker)
 {
   if (!checker)
-    throw std::invalid_argument("version support checker cannot be null");
-  std::lock_guard<std::mutex> lock(version_support_registry_mutex());
+    NAM_THROW(std::invalid_argument("version support checker cannot be null"));
+  LockGuard lock(version_support_registry_mutex());
   version_support_registry().push_back(std::move(checker));
 }
 
 Supported is_version_supported(const std::string version)
 {
-  std::lock_guard<std::mutex> lock(version_support_registry_mutex());
+  LockGuard lock(version_support_registry_mutex());
   Supported best_support = Supported::NO;
   for (const auto& checker : version_support_registry())
   {
@@ -115,19 +117,11 @@ void verify_config_version(const std::string versionStr)
 {
   const Supported support = is_version_supported(versionStr);
   if (support == Supported::NO)
-  {
-    std::stringstream ss;
-    ss << "Model config is an unsupported version " << versionStr << ".";
-    throw std::runtime_error(ss.str());
-  }
-  if (support == Supported::PARTIAL)
-  {
-    std::stringstream ss;
-    std::cerr << "Model config is a partially-supported version " << versionStr << ". Continuing with partial support."
-              << std::endl;
-  }
+    NAM_THROW(std::runtime_error("Model config is an unsupported version " + versionStr + "."));
+  // Partially-supported versions are accepted as-is.
 }
 
+#if NAM_HAS_JSON
 std::vector<float> GetWeights(nlohmann::json const& j)
 {
   auto it = j.find("weights");
@@ -136,7 +130,7 @@ std::vector<float> GetWeights(nlohmann::json const& j)
     return *it;
   }
   else
-    throw std::runtime_error("Corrupted model file is missing weights.");
+    NAM_THROW(std::runtime_error("Corrupted model file is missing weights."));
 }
 
 void populate_dsp_data(const nlohmann::json& config, dspData& returnedConfig)
@@ -170,7 +164,7 @@ std::unique_ptr<DSP> get_dsp(const std::filesystem::path config_filename, dspDat
                              DspLoadOptions options)
 {
   if (!std::filesystem::exists(config_filename))
-    throw std::runtime_error("Config file doesn't exist!\n");
+    NAM_THROW(std::runtime_error("Config file doesn't exist!\n"));
   std::ifstream i(config_filename);
   nlohmann::json j;
   i >> j;
@@ -207,6 +201,7 @@ std::unique_ptr<ModelConfig> parse_model_config_json(const std::string& architec
 {
   return ConfigParserRegistry::instance().parse(architecture, config, sample_rate);
 }
+#endif // NAM_HAS_JSON
 
 namespace
 {
@@ -231,10 +226,7 @@ std::unique_ptr<DSP> create_dsp(std::unique_ptr<ModelConfig> config, std::vector
   return out;
 }
 
-// =============================================================================
-// get_dsp(dspData&) — now uses unified path
-// =============================================================================
-
+#if NAM_HAS_JSON
 namespace
 {
 
@@ -284,5 +276,6 @@ double get_sample_rate_from_nam_file(const nlohmann::json& j)
   else
     return -1.0;
 }
+#endif // NAM_HAS_JSON
 
 }; // namespace nam

--- a/NAM/get_dsp.h
+++ b/NAM/get_dsp.h
@@ -1,11 +1,14 @@
 #pragma once
 
-#include <fstream>
 #include <memory>
 #include <optional>
 #include <vector>
 
 #include "dsp.h"
+
+#if NAM_HAS_JSON
+  #include <fstream>
+#endif
 
 namespace nam
 {
@@ -77,6 +80,7 @@ struct DspLoadOptions
   std::optional<bool> prewarm = std::nullopt;
 };
 
+#if NAM_HAS_JSON
 /// \brief Get NAM from a .nam file at the provided location
 /// \param config_filename Path to the .nam model file
 /// \param options Loading options
@@ -117,4 +121,5 @@ std::unique_ptr<DSP> get_dsp(const nlohmann::json& config, DspLoadOptions option
 /// \param j JSON object from the .nam file
 /// \return Sample rate in Hz, or -1 if not known (really old .nam files)
 double get_sample_rate_from_nam_file(const nlohmann::json& j);
+#endif // NAM_HAS_JSON
 }; // namespace nam

--- a/NAM/linear.cpp
+++ b/NAM/linear.cpp
@@ -3,8 +3,7 @@
 #include <algorithm>
 #include <cctype>
 #include <complex>
-#include <stdexcept>
-
+#include "compiler.h"
 #include "registry.h"
 
 #include <unsupported/Eigen/FFT>
@@ -66,9 +65,9 @@ nam::Linear::Linear(const int in_channels, const int out_channels, const int rec
 , _active_implementation(LinearImplementation::Direct)
 {
   if ((int)weights.size() != (receptive_field + (_bias ? 1 : 0)))
-    throw std::runtime_error(
+    NAM_THROW(std::runtime_error(
       "Params vector does not match expected size based "
-      "on architecture parameters");
+      "on architecture parameters"));
 
   this->_impulse_response.assign(weights.begin(), weights.begin() + receptive_field);
   this->_weight.resize(this->_receptive_field);
@@ -289,7 +288,7 @@ nam::LinearImplementation nam::linear::parse_implementation(const std::string& i
     return LinearImplementation::Direct;
   if (normalized == "fft" || normalized == "partitioned_fft" || normalized == "partitioned-fft")
     return LinearImplementation::FFT;
-  throw std::runtime_error("Unsupported Linear implementation: " + implementation);
+  NAM_THROW(std::runtime_error("Unsupported Linear implementation: " + implementation));
 }
 
 std::string nam::linear::implementation_to_string(const LinearImplementation implementation)
@@ -300,9 +299,10 @@ std::string nam::linear::implementation_to_string(const LinearImplementation imp
     case LinearImplementation::Direct: return "direct";
     case LinearImplementation::FFT: return "fft";
   }
-  throw std::runtime_error("Unsupported Linear implementation enum");
+  NAM_THROW(std::runtime_error("Unsupported Linear implementation enum"));
 }
 
+#if NAM_HAS_JSON
 nam::linear::LinearConfig nam::linear::parse_config_json(const nlohmann::json& config)
 {
   LinearConfig c;
@@ -314,6 +314,7 @@ nam::linear::LinearConfig nam::linear::parse_config_json(const nlohmann::json& c
   c.implementation = parse_implementation(config.value("implementation", "auto"));
   return c;
 }
+#endif
 
 std::unique_ptr<nam::DSP> nam::linear::LinearConfig::create(std::vector<float> weights, double sampleRate)
 {
@@ -321,6 +322,7 @@ std::unique_ptr<nam::DSP> nam::linear::LinearConfig::create(std::vector<float> w
     in_channels, out_channels, receptive_field, bias, weights, sampleRate, implementation);
 }
 
+#if NAM_HAS_JSON
 std::unique_ptr<nam::ModelConfig> nam::linear::create_config(const nlohmann::json& config, double sampleRate)
 {
   (void)sampleRate;
@@ -334,3 +336,4 @@ namespace
 {
 static nam::ConfigParserHelper _register_Linear("Linear", nam::linear::create_config);
 }
+#endif // NAM_HAS_JSON

--- a/NAM/linear.h
+++ b/NAM/linear.h
@@ -86,6 +86,7 @@ LinearImplementation parse_implementation(const std::string& implementation);
 /// \brief String name for a Linear implementation.
 std::string implementation_to_string(const LinearImplementation implementation);
 
+#if NAM_HAS_JSON
 /// \brief Parse Linear configuration from JSON
 /// \param config JSON configuration object
 /// \return LinearConfig
@@ -96,6 +97,7 @@ LinearConfig parse_config_json(const nlohmann::json& config);
 /// \param sampleRate Expected sample rate in Hz
 /// \return unique_ptr<ModelConfig> wrapping a LinearConfig
 std::unique_ptr<ModelConfig> create_config(const nlohmann::json& config, double sampleRate);
+#endif
 } // namespace linear
 
 } // namespace nam

--- a/NAM/lstm.cpp
+++ b/NAM/lstm.cpp
@@ -168,6 +168,7 @@ void nam::lstm::LSTM::_process_sample()
 }
 
 // Config parser
+#if NAM_HAS_JSON
 nam::lstm::LSTMConfig nam::lstm::parse_config_json(const nlohmann::json& config)
 {
   LSTMConfig c;
@@ -179,6 +180,7 @@ nam::lstm::LSTMConfig nam::lstm::parse_config_json(const nlohmann::json& config)
   c.out_channels = config.value("out_channels", 1);
   return c;
 }
+#endif
 
 // LSTMConfig::create()
 std::unique_ptr<nam::DSP> nam::lstm::LSTMConfig::create(std::vector<float> weights, double sampleRate)
@@ -188,6 +190,7 @@ std::unique_ptr<nam::DSP> nam::lstm::LSTMConfig::create(std::vector<float> weigh
 }
 
 // Config parser for ConfigParserRegistry
+#if NAM_HAS_JSON
 std::unique_ptr<nam::ModelConfig> nam::lstm::create_config(const nlohmann::json& config, double sampleRate)
 {
   (void)sampleRate;
@@ -202,3 +205,4 @@ namespace
 {
 static nam::ConfigParserHelper _register_LSTM("LSTM", nam::lstm::create_config);
 }
+#endif // NAM_HAS_JSON

--- a/NAM/lstm.h
+++ b/NAM/lstm.h
@@ -114,6 +114,7 @@ struct LSTMConfig : public ModelConfig
   std::unique_ptr<DSP> create(std::vector<float> weights, double sampleRate) override;
 };
 
+#if NAM_HAS_JSON
 /// \brief Parse LSTM configuration from JSON
 /// \param config JSON configuration object
 /// \return LSTMConfig
@@ -121,6 +122,7 @@ LSTMConfig parse_config_json(const nlohmann::json& config);
 
 /// \brief Config parser for ConfigParserRegistry
 std::unique_ptr<ModelConfig> create_config(const nlohmann::json& config, double sampleRate);
+#endif
 
 }; // namespace lstm
 }; // namespace nam

--- a/NAM/model_config.h
+++ b/NAM/model_config.h
@@ -5,12 +5,14 @@
 #include <functional>
 #include <memory>
 #include <optional>
-#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "compiler.h"
 
-#include "json.hpp"
+#if NAM_HAS_JSON
+  #include "json.hpp"
+#endif
 
 namespace nam
 {
@@ -44,6 +46,7 @@ public:
   virtual std::unique_ptr<DSP> create(std::vector<float> weights, double sampleRate) = 0;
 };
 
+#if NAM_HAS_JSON
 /// \brief Function type for parsing a ModelConfig from JSON
 using ConfigParserFunction = std::function<std::unique_ptr<ModelConfig>(const nlohmann::json&, double)>;
 
@@ -68,7 +71,7 @@ public:
   {
     if (parsers_.find(name) != parsers_.end())
     {
-      throw std::runtime_error("Config parser already registered for: " + name);
+      NAM_THROW(std::runtime_error("Config parser already registered for: " + name));
     }
     parsers_[name] = std::move(func);
   }
@@ -83,7 +86,7 @@ public:
     auto it = parsers_.find(name);
     if (it == parsers_.end())
     {
-      throw std::runtime_error("No config parser registered for architecture: " + name);
+      NAM_THROW(std::runtime_error("No config parser registered for architecture: " + name));
     }
     return it->second(config, sampleRate);
   }
@@ -102,6 +105,7 @@ struct ConfigParserHelper
     ConfigParserRegistry::instance().registerParser(name, std::move(func));
   }
 };
+#endif // NAM_HAS_JSON
 
 /// \brief Construct a DSP object from a typed config, weights, and metadata
 ///
@@ -114,6 +118,7 @@ struct ConfigParserHelper
 std::unique_ptr<DSP> create_dsp(std::unique_ptr<ModelConfig> config, std::vector<float> weights,
                                 const ModelMetadata& metadata);
 
+#if NAM_HAS_JSON
 /// \brief Parse a ModelConfig from a JSON architecture name and config block
 /// \param architecture Architecture name string (e.g., "WaveNet", "LSTM")
 /// \param config JSON config block for this architecture
@@ -121,5 +126,6 @@ std::unique_ptr<DSP> create_dsp(std::unique_ptr<ModelConfig> config, std::vector
 /// \return unique_ptr<ModelConfig>
 std::unique_ptr<ModelConfig> parse_model_config_json(const std::string& architecture, const nlohmann::json& config,
                                                      double sample_rate);
+#endif
 
 } // namespace nam

--- a/NAM/registry.h
+++ b/NAM/registry.h
@@ -13,6 +13,8 @@
 
 #include "dsp.h"
 
+#if NAM_HAS_JSON
+
 namespace nam
 {
 namespace factory
@@ -67,3 +69,5 @@ struct Helper
 };
 } // namespace factory
 } // namespace nam
+
+#endif // NAM_HAS_JSON

--- a/NAM/wavenet/a2_fast.cpp
+++ b/NAM/wavenet/a2_fast.cpp
@@ -67,6 +67,11 @@ public:
 
   void process(NAM_SAMPLE** input, NAM_SAMPLE** output, int num_frames) override;
   int GetPrewarmSamples() override { return _prewarm_samples; }
+  void SetLayerObserver(LayerObserver observer, void* context) override
+  {
+    _layer_observer = observer;
+    _layer_observer_context = context;
+  }
 
 protected:
   void SetMaxBufferSize(int maxBufferSize) override;
@@ -141,6 +146,8 @@ private:
   std::vector<float> _head_out; // float32 head output before writing to NAM_SAMPLE
 
   int _prewarm_samples = 0;
+  LayerObserver _layer_observer = nullptr;
+  void* _layer_observer_context = nullptr;
 
   void _load_weights(std::vector<float>& weights);
   void _ring_write(Layer& L, int num_frames);
@@ -618,7 +625,7 @@ void A2FastModel<Channels>::_layer_forward(int layer_idx, const float* cond, int
   {
     case 6: _layer_forward_k<6>(L, cond, num_frames); break;
     case 15: _layer_forward_k<15>(L, cond, num_frames); break;
-    default: throw std::runtime_error("A2FastModel: unexpected kernel_size " + std::to_string(L.kernel_size));
+    default: NAM_THROW(std::runtime_error("A2FastModel: unexpected kernel_size " + std::to_string(L.kernel_size)));
   }
 }
 
@@ -679,8 +686,23 @@ void A2FastModel<Channels>::process(NAM_SAMPLE** input, NAM_SAMPLE** output, int
   // Zero head accumulator.
   std::memset(_head_sum.data(), 0, static_cast<size_t>(num_frames) * Channels * sizeof(float));
 
-  for (int li = 0; li < kNumLayers; li++)
-    _layer_forward(li, cond, num_frames);
+  if (_layer_observer != nullptr)
+  {
+    for (int li = 0; li < kNumLayers; li++)
+    {
+      _layer_observer(_layer_observer_context, 0, li, true);
+      _layer_forward(li, cond, num_frames);
+      _layer_observer(_layer_observer_context, 0, li, false);
+    }
+  }
+  else
+  {
+    for (int li = 0; li < kNumLayers; li++)
+    {
+      _layer_forward(li, cond, num_frames);
+    }
+  }
+
 
   // Output.
   float* head_out = _head_out.data();
@@ -705,6 +727,20 @@ struct A2FastConfig : public ModelConfig
     NAM_THROW(std::runtime_error("A2FastConfig: unsupported channel count " + std::to_string(channels)));
   }
 };
+
+} // namespace
+
+std::unique_ptr<ModelConfig> create_a2_fast_config(const int channels)
+{
+  auto out = std::make_unique<A2FastConfig>();
+  out->channels = channels;
+  return out;
+}
+
+#if NAM_HAS_JSON
+
+namespace
+{
 
 // -----------------------------------------------------------------------------
 // Detector helpers
@@ -915,10 +951,10 @@ std::unique_ptr<ModelConfig> create_a2_fast_config(const nlohmann::json& config,
   int ch = 0;
   if (!is_a2_shape(config, &ch))
     NAM_THROW(std::runtime_error("create_a2_fast_config: config does not match A2 shape"));
-  auto out = std::make_unique<A2FastConfig>();
-  out->channels = ch;
-  return out;
+  return create_a2_fast_config(ch);
 }
+
+#endif // NAM_HAS_JSON
 
 } // namespace a2_fast
 } // namespace wavenet

--- a/NAM/wavenet/a2_fast.cpp
+++ b/NAM/wavenet/a2_fast.cpp
@@ -121,11 +121,6 @@ public:
   void process(NAM_SAMPLE** input, NAM_SAMPLE** output, int num_frames) override;
   void prewarm() override;
   int GetPrewarmSamples() override { return _prewarm_samples; }
-  void SetLayerObserver(LayerObserver observer, void* context) override
-  {
-    _layer_observer = observer;
-    _layer_observer_context = context;
-  }
 
 protected:
   void SetMaxBufferSize(int maxBufferSize) override;
@@ -204,8 +199,6 @@ private:
   std::vector<float> _head_out; // float32 head output before writing to NAM_SAMPLE
 
   int _prewarm_samples = 0;
-  LayerObserver _layer_observer = nullptr;
-  void* _layer_observer_context = nullptr;
   bool _has_cached_prewarm_state = false;
 
   void _load_weights(std::vector<float>& weights);
@@ -821,21 +814,9 @@ void A2FastModel<Channels>::process(NAM_SAMPLE** input, NAM_SAMPLE** output, int
   // Zero head accumulator.
   std::memset(_head_sum.data(), 0, static_cast<size_t>(num_frames) * Channels * sizeof(float));
 
-  if (_layer_observer != nullptr)
+  for (int li = 0; li < kNumLayers; li++)
   {
-    for (int li = 0; li < kNumLayers; li++)
-    {
-      _layer_observer(_layer_observer_context, 0, li, true);
-      _layer_forward(li, cond, num_frames);
-      _layer_observer(_layer_observer_context, 0, li, false);
-    }
-  }
-  else
-  {
-    for (int li = 0; li < kNumLayers; li++)
-    {
-      _layer_forward(li, cond, num_frames);
-    }
+    _layer_forward(li, cond, num_frames);
   }
 
 

--- a/NAM/wavenet/a2_fast.cpp
+++ b/NAM/wavenet/a2_fast.cpp
@@ -27,6 +27,23 @@
 
   #include "../dsp.h"
 
+  // Manual placement of fast code sections into NAM_SECTION_CODE_FAST
+  // GCC drops section attributes from implicit template specializations when they are applied to the primary template, 
+  // so we must explicitly instantiate the methods we want in NAM_SECTION_CODE_FAST
+  #define NAM_INSTANTIATE_A2_FAST_METHODS(ChannelCount) \
+    template NAM_SECTION_CODE_FAST void A2FastModel<ChannelCount>::_ring_write( \
+      A2FastModel<ChannelCount>::Layer&, int); \
+    template NAM_SECTION_CODE_FAST void A2FastModel<ChannelCount>::_head_ring_write(int); \
+    template NAM_SECTION_CODE_FAST void A2FastModel<ChannelCount>::_layer_forward( \
+      int, const float*, int); \
+    template NAM_SECTION_CODE_FAST void A2FastModel<ChannelCount>::_head_forward(float*, int); \
+    template NAM_SECTION_CODE_FAST void A2FastModel<ChannelCount>::_layer_forward_k<6>( \
+      A2FastModel<ChannelCount>::Layer&, const float*, int); \
+    template NAM_SECTION_CODE_FAST void A2FastModel<ChannelCount>::_layer_forward_k<15>( \
+      A2FastModel<ChannelCount>::Layer&, const float*, int); \
+    template NAM_SECTION_CODE_FAST void A2FastModel<ChannelCount>::process( \
+      NAM_SAMPLE**, NAM_SAMPLE**, int);
+
 namespace nam
 {
 namespace wavenet
@@ -101,7 +118,7 @@ public:
   A2FastModel(std::vector<float> weights, double expected_sample_rate);
   ~A2FastModel() override = default;
 
-  NAM_SECTION_CODE_FAST void process(NAM_SAMPLE** input, NAM_SAMPLE** output, int num_frames) override;
+  void process(NAM_SAMPLE** input, NAM_SAMPLE** output, int num_frames) override;
   void prewarm() override;
   int GetPrewarmSamples() override { return _prewarm_samples; }
   void SetLayerObserver(LayerObserver observer, void* context) override
@@ -195,16 +212,16 @@ private:
   bool HasCachedPrewarmState() const { return _has_cached_prewarm_state; }
   void PrewarmFromCache();
   void CacheStateAsPrewarmed();
-  NAM_SECTION_CODE_FAST void _ring_write(Layer& L, int num_frames);
-  NAM_SECTION_CODE_FAST void _head_ring_write(int num_frames);
-  NAM_SECTION_CODE_FAST void _layer_forward(int layer_idx, const float* cond, int num_frames);
-  NAM_SECTION_CODE_FAST void _head_forward(float* output, int num_frames);
+  void _ring_write(Layer& L, int num_frames);
+  void _head_ring_write(int num_frames);
+  void _layer_forward(int layer_idx, const float* cond, int num_frames);
+  void _head_forward(float* output, int num_frames);
 
   // Compile-time-specialized per-layer kernel. KernelSize is lifted to a
   // template parameter so clang can fully unroll the tap loop and schedule
   // FMAs across taps. For the A2 shape we only need K=6 and K=15.
   template <int KernelSize>
-  NAM_SECTION_CODE_FAST void _layer_forward_k(Layer& L, const float* cond, int num_frames);
+  void _layer_forward_k(Layer& L, const float* cond, int num_frames);
 };
 
 // -----------------------------------------------------------------------------
@@ -461,7 +478,7 @@ void A2FastModel<Channels>::CacheStateAsPrewarmed()
 //   and reset write_pos. That memmove is the jitter spike we're measuring.
 // -----------------------------------------------------------------------------
 template <int Channels>
-NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_ring_write(Layer& L, int num_frames)
+void A2FastModel<Channels>::_ring_write(Layer& L, int num_frames)
 {
   #if NAM_A2_RING_MODE == 1
   const int mbs = GetMaxBufferSize();
@@ -494,7 +511,7 @@ NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_ring_write(Layer& L, int num_
 }
 
 template <int Channels>
-NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_head_ring_write(int num_frames)
+void A2FastModel<Channels>::_head_ring_write(int num_frames)
 {
   #if NAM_A2_RING_MODE == 1
   const int mbs = GetMaxBufferSize();
@@ -537,7 +554,7 @@ NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_head_ring_write(int num_frame
 // runtime dispatcher below for each A2 kernel size (6 and 15).
 template <int Channels>
 template <int KernelSize>
-NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_layer_forward_k(Layer& L, const float* cond, int num_frames)
+void A2FastModel<Channels>::_layer_forward_k(Layer& L, const float* cond, int num_frames)
 {
   constexpr int K = KernelSize;
   const int D = L.dilation;
@@ -735,7 +752,7 @@ NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_layer_forward_k(Layer& L, con
 // For the A2 shape the detector only admits K in {6, 15}; any other value
 // here means something passed the detector that shouldn't have.
 template <int Channels>
-NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_layer_forward(int layer_idx, const float* cond, int num_frames)
+void A2FastModel<Channels>::_layer_forward(int layer_idx, const float* cond, int num_frames)
 {
   Layer& L = _layers[layer_idx];
   _ring_write(L, num_frames);
@@ -751,7 +768,7 @@ NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_layer_forward(int layer_idx, 
 // Head: K=16 dilation-1 conv from Channels to 1, plus bias + scale.
 // -----------------------------------------------------------------------------
 template <int Channels>
-NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_head_forward(float* output, int num_frames)
+void A2FastModel<Channels>::_head_forward(float* output, int num_frames)
 {
   _head_ring_write(num_frames);
   #if NAM_A2_RING_MODE == 1
@@ -781,7 +798,7 @@ NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_head_forward(float* output, i
 // DSP::process override
 // -----------------------------------------------------------------------------
 template <int Channels>
-NAM_SECTION_CODE_FAST void A2FastModel<Channels>::process(NAM_SAMPLE** input, NAM_SAMPLE** output, int num_frames)
+void A2FastModel<Channels>::process(NAM_SAMPLE** input, NAM_SAMPLE** output, int num_frames)
 {
   if (num_frames > GetMaxBufferSize())
     SetMaxBufferSize(num_frames);
@@ -828,6 +845,11 @@ NAM_SECTION_CODE_FAST void A2FastModel<Channels>::process(NAM_SAMPLE** input, NA
   for (int f = 0; f < num_frames; f++)
     out0[f] = static_cast<NAM_SAMPLE>(head_out[f]);
 }
+
+  NAM_INSTANTIATE_A2_FAST_METHODS(3)
+  NAM_INSTANTIATE_A2_FAST_METHODS(8)
+
+  #undef NAM_INSTANTIATE_A2_FAST_METHODS
 
 // -----------------------------------------------------------------------------
 // A2FastConfig — wraps the constructed DSP behind the ModelConfig interface.

--- a/NAM/wavenet/a2_fast.cpp
+++ b/NAM/wavenet/a2_fast.cpp
@@ -207,7 +207,7 @@ void A2FastModel<Channels>::_load_weights(std::vector<float>& weights)
 
   auto take = [&]() -> float {
     if (it == end)
-      throw std::runtime_error("A2FastModel: weight stream exhausted");
+      NAM_THROW(std::runtime_error("A2FastModel: weight stream exhausted"));
     return *it++;
   };
 
@@ -272,7 +272,7 @@ void A2FastModel<Channels>::_load_weights(std::vector<float>& weights)
   {
     std::stringstream ss;
     ss << "A2FastModel: weight stream has " << std::distance(it, end) << " trailing bytes";
-    throw std::runtime_error(ss.str());
+    NAM_THROW(std::runtime_error(ss.str()));
   }
 }
 
@@ -702,7 +702,7 @@ struct A2FastConfig : public ModelConfig
       return std::make_unique<A2FastModel<3>>(std::move(weights), sampleRate);
     if (channels == 8)
       return std::make_unique<A2FastModel<8>>(std::move(weights), sampleRate);
-    throw std::runtime_error("A2FastConfig: unsupported channel count " + std::to_string(channels));
+    NAM_THROW(std::runtime_error("A2FastConfig: unsupported channel count " + std::to_string(channels)));
   }
 };
 
@@ -914,7 +914,7 @@ std::unique_ptr<ModelConfig> create_a2_fast_config(const nlohmann::json& config,
   (void)sampleRate;
   int ch = 0;
   if (!is_a2_shape(config, &ch))
-    throw std::runtime_error("create_a2_fast_config: config does not match A2 shape");
+    NAM_THROW(std::runtime_error("create_a2_fast_config: config does not match A2 shape"));
   auto out = std::make_unique<A2FastConfig>();
   out->channels = ch;
   return out;

--- a/NAM/wavenet/a2_fast.cpp
+++ b/NAM/wavenet/a2_fast.cpp
@@ -37,6 +37,42 @@ namespace a2_fast
 namespace
 {
 
+NAM_SECTION_CODE_FAST inline void update_tail_mirror(
+    float* history,
+    int pow2_size,
+    int max_buffer_size,
+    int channels,
+    int write_pos,
+    int first,
+    int wrapped,
+    bool& initialized)
+{
+  const size_t sample_bytes = sizeof(float) * static_cast<size_t>(channels);
+  if (!initialized)
+  {
+    std::memcpy(history + static_cast<size_t>(pow2_size) * channels,
+                history,
+                static_cast<size_t>(max_buffer_size) * sample_bytes);
+    initialized = true;
+    return;
+  }
+
+  if (write_pos < max_buffer_size)
+  {
+    const int mirrored = std::min(first, max_buffer_size - write_pos);
+    std::memcpy(history + static_cast<size_t>(pow2_size + write_pos) * channels,
+                history + static_cast<size_t>(write_pos) * channels,
+                static_cast<size_t>(mirrored) * sample_bytes);
+  }
+  if (wrapped > 0)
+  {
+    const int mirrored = std::min(wrapped, max_buffer_size);
+    std::memcpy(history + static_cast<size_t>(pow2_size) * channels,
+                history,
+                static_cast<size_t>(mirrored) * sample_bytes);
+  }
+}
+
 // =============================================================================
 // A2FastModel<Channels>
 //
@@ -65,7 +101,7 @@ public:
   A2FastModel(std::vector<float> weights, double expected_sample_rate);
   ~A2FastModel() override = default;
 
-  void process(NAM_SAMPLE** input, NAM_SAMPLE** output, int num_frames) override;
+  NAM_SECTION_CODE_FAST void process(NAM_SAMPLE** input, NAM_SAMPLE** output, int num_frames) override;
   void prewarm() override;
   int GetPrewarmSamples() override { return _prewarm_samples; }
   void SetLayerObserver(LayerObserver observer, void* context) override
@@ -107,6 +143,7 @@ private:
     int pow2_size = 0;
     int pow2_mask = 0;
     int write_pos = 0;
+    bool mirror_initialized = false;
   #else
     // Linear ring with sporadic memmove-rewind. history_cols = 2*max_lookback +
     // max_buffer_size; write_pos grows monotonically until rewind fires.
@@ -136,6 +173,7 @@ private:
   int _head_pow2_size = 0;
   int _head_pow2_mask = 0;
   int _head_write_pos = 0;
+  bool _head_mirror_initialized = false;
   #else
   int _head_history_cols = 0;
   int _head_write_pos = 0;
@@ -157,16 +195,16 @@ private:
   bool HasCachedPrewarmState() const { return _has_cached_prewarm_state; }
   void PrewarmFromCache();
   void CacheStateAsPrewarmed();
-  void _ring_write(Layer& L, int num_frames);
-  void _head_ring_write(int num_frames);
-  void _layer_forward(int layer_idx, const float* cond, int num_frames);
-  void _head_forward(float* output, int num_frames);
+  NAM_SECTION_CODE_FAST void _ring_write(Layer& L, int num_frames);
+  NAM_SECTION_CODE_FAST void _head_ring_write(int num_frames);
+  NAM_SECTION_CODE_FAST void _layer_forward(int layer_idx, const float* cond, int num_frames);
+  NAM_SECTION_CODE_FAST void _head_forward(float* output, int num_frames);
 
   // Compile-time-specialized per-layer kernel. KernelSize is lifted to a
   // template parameter so clang can fully unroll the tap loop and schedule
   // FMAs across taps. For the A2 shape we only need K=6 and K=15.
   template <int KernelSize>
-  void _layer_forward_k(Layer& L, const float* cond, int num_frames);
+  NAM_SECTION_CODE_FAST void _layer_forward_k(Layer& L, const float* cond, int num_frames);
 };
 
 // -----------------------------------------------------------------------------
@@ -323,6 +361,7 @@ void A2FastModel<Channels>::SetMaxBufferSize(int maxBufferSize)
     L.pow2_mask = L.pow2_size - 1;
     L.history.assign(static_cast<size_t>(Channels) * (L.pow2_size + maxBufferSize), 0.0f);
     L.write_pos = L.max_lookback;
+    L.mirror_initialized = false;
   #else
     L.history_cols = 2 * L.max_lookback + maxBufferSize;
     L.history.assign(static_cast<size_t>(Channels) * L.history_cols, 0.0f);
@@ -336,6 +375,7 @@ void A2FastModel<Channels>::SetMaxBufferSize(int maxBufferSize)
   _head_pow2_mask = _head_pow2_size - 1;
   _head_history.assign(static_cast<size_t>(Channels) * (_head_pow2_size + maxBufferSize), 0.0f);
   _head_write_pos = head_lookback;
+  _head_mirror_initialized = false;
   #else
   _head_history_cols = 2 * head_lookback + maxBufferSize;
   _head_history.assign(static_cast<size_t>(Channels) * _head_history_cols, 0.0f);
@@ -375,6 +415,7 @@ void A2FastModel<Channels>::PrewarmFromCache()
                 L.history.begin() + static_cast<std::ptrdiff_t>(column * Channels));
     }
     L.write_pos = L.max_lookback;
+    L.mirror_initialized = true;
   }
 
   const size_t head_columns = _head_history.size() / Channels;
@@ -384,6 +425,7 @@ void A2FastModel<Channels>::PrewarmFromCache()
               _head_history.begin() + static_cast<std::ptrdiff_t>(column * Channels));
   }
   _head_write_pos = kHeadKernelSize - 1;
+  _head_mirror_initialized = true;
 }
 
 template <int Channels>
@@ -419,7 +461,7 @@ void A2FastModel<Channels>::CacheStateAsPrewarmed()
 //   and reset write_pos. That memmove is the jitter spike we're measuring.
 // -----------------------------------------------------------------------------
 template <int Channels>
-void A2FastModel<Channels>::_ring_write(Layer& L, int num_frames)
+NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_ring_write(Layer& L, int num_frames)
 {
   #if NAM_A2_RING_MODE == 1
   const int mbs = GetMaxBufferSize();
@@ -427,14 +469,15 @@ void A2FastModel<Channels>::_ring_write(Layer& L, int num_frames)
   const float* const src = _layer_in.data();
   const int wp = L.write_pos;
   const int first = std::min(num_frames, L.pow2_size - wp);
+  const int wrapped = num_frames - first;
   std::memcpy(hist + static_cast<size_t>(wp) * Channels, src, static_cast<size_t>(first) * Channels * sizeof(float));
-  if (first < num_frames)
+  if (wrapped > 0)
   {
     std::memcpy(hist, src + static_cast<size_t>(first) * Channels,
-                static_cast<size_t>(num_frames - first) * Channels * sizeof(float));
+                static_cast<size_t>(wrapped) * Channels * sizeof(float));
   }
-  std::memcpy(
-    hist + static_cast<size_t>(L.pow2_size) * Channels, hist, static_cast<size_t>(mbs) * Channels * sizeof(float));
+  update_tail_mirror(hist, L.pow2_size, mbs, Channels, wp, first, wrapped,
+                          L.mirror_initialized);
   L.write_pos = (wp + num_frames) & L.pow2_mask;
   #else
   if (L.write_pos + num_frames > L.history_cols)
@@ -451,7 +494,7 @@ void A2FastModel<Channels>::_ring_write(Layer& L, int num_frames)
 }
 
 template <int Channels>
-void A2FastModel<Channels>::_head_ring_write(int num_frames)
+NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_head_ring_write(int num_frames)
 {
   #if NAM_A2_RING_MODE == 1
   const int mbs = GetMaxBufferSize();
@@ -459,14 +502,15 @@ void A2FastModel<Channels>::_head_ring_write(int num_frames)
   const float* const src = _head_sum.data();
   const int wp = _head_write_pos;
   const int first = std::min(num_frames, _head_pow2_size - wp);
+  const int wrapped = num_frames - first;
   std::memcpy(hist + static_cast<size_t>(wp) * Channels, src, static_cast<size_t>(first) * Channels * sizeof(float));
-  if (first < num_frames)
+  if (wrapped > 0)
   {
     std::memcpy(hist, src + static_cast<size_t>(first) * Channels,
-                static_cast<size_t>(num_frames - first) * Channels * sizeof(float));
+                static_cast<size_t>(wrapped) * Channels * sizeof(float));
   }
-  std::memcpy(
-    hist + static_cast<size_t>(_head_pow2_size) * Channels, hist, static_cast<size_t>(mbs) * Channels * sizeof(float));
+  update_tail_mirror(hist, _head_pow2_size, mbs, Channels, wp, first, wrapped,
+                          _head_mirror_initialized);
   _head_write_pos = (wp + num_frames) & _head_pow2_mask;
   #else
   const int keep = kHeadKernelSize - 1;
@@ -493,7 +537,7 @@ void A2FastModel<Channels>::_head_ring_write(int num_frames)
 // runtime dispatcher below for each A2 kernel size (6 and 15).
 template <int Channels>
 template <int KernelSize>
-void A2FastModel<Channels>::_layer_forward_k(Layer& L, const float* cond, int num_frames)
+NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_layer_forward_k(Layer& L, const float* cond, int num_frames)
 {
   constexpr int K = KernelSize;
   const int D = L.dilation;
@@ -691,7 +735,7 @@ void A2FastModel<Channels>::_layer_forward_k(Layer& L, const float* cond, int nu
 // For the A2 shape the detector only admits K in {6, 15}; any other value
 // here means something passed the detector that shouldn't have.
 template <int Channels>
-void A2FastModel<Channels>::_layer_forward(int layer_idx, const float* cond, int num_frames)
+NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_layer_forward(int layer_idx, const float* cond, int num_frames)
 {
   Layer& L = _layers[layer_idx];
   _ring_write(L, num_frames);
@@ -707,7 +751,7 @@ void A2FastModel<Channels>::_layer_forward(int layer_idx, const float* cond, int
 // Head: K=16 dilation-1 conv from Channels to 1, plus bias + scale.
 // -----------------------------------------------------------------------------
 template <int Channels>
-void A2FastModel<Channels>::_head_forward(float* output, int num_frames)
+NAM_SECTION_CODE_FAST void A2FastModel<Channels>::_head_forward(float* output, int num_frames)
 {
   _head_ring_write(num_frames);
   #if NAM_A2_RING_MODE == 1
@@ -737,7 +781,7 @@ void A2FastModel<Channels>::_head_forward(float* output, int num_frames)
 // DSP::process override
 // -----------------------------------------------------------------------------
 template <int Channels>
-void A2FastModel<Channels>::process(NAM_SAMPLE** input, NAM_SAMPLE** output, int num_frames)
+NAM_SECTION_CODE_FAST void A2FastModel<Channels>::process(NAM_SAMPLE** input, NAM_SAMPLE** output, int num_frames)
 {
   if (num_frames > GetMaxBufferSize())
     SetMaxBufferSize(num_frames);

--- a/NAM/wavenet/a2_fast.h
+++ b/NAM/wavenet/a2_fast.h
@@ -18,7 +18,9 @@
   #include <memory>
 
   #include "../model_config.h"
-  #include "json.hpp"
+  #if NAM_HAS_JSON
+    #include "json.hpp"
+  #endif
 
 namespace nam
 {
@@ -46,11 +48,18 @@ inline constexpr std::array<int, kNumLayers> kDilations = {
 /// \param config   The "config" sub-object from a .nam WaveNet entry.
 /// \param channels Out-param set to 3 (A2 nano) or 8 (A2 standard) on match.
 /// \return true if every architectural knob matches the A2 signature exactly.
+#if NAM_HAS_JSON
 bool is_a2_shape(const nlohmann::json& config, int* channels);
 
 /// \brief Build a ModelConfig that instantiates the A2 fast path.
 /// \pre is_a2_shape(config, ...) returned true.
 std::unique_ptr<ModelConfig> create_a2_fast_config(const nlohmann::json& config, double sampleRate);
+#endif
+
+/// \brief Build a ModelConfig that instantiates the A2 fast path from channel count.
+/// \param channels Must be 3 (A2 nano) or 8 (A2 standard).
+/// 	hrows std::runtime_error for unsupported channel counts.
+std::unique_ptr<ModelConfig> create_a2_fast_config(int channels);
 
 } // namespace a2_fast
 } // namespace wavenet

--- a/NAM/wavenet/detail.h
+++ b/NAM/wavenet/detail.h
@@ -9,6 +9,7 @@
 #include <Eigen/Dense>
 
 #include "../conv1d.h"
+#include "../dsp.h"
 #include "../gating_activations.h"
 #include "../film.h"
 #include "../compiler.h"
@@ -302,6 +303,9 @@ public:
   void Process(const Eigen::MatrixXf& layer_inputs, const Eigen::MatrixXf& condition,
                const Eigen::MatrixXf& head_inputs, const int num_frames);
 
+  void SetObserver(DSP::LayerObserver observer, void* context,
+                   size_t layerArrayIndex);
+
   /// \brief Get output from last layer (for next layer array)
   ///
   /// Returns the full pre-allocated buffer; only the first num_frames columns
@@ -352,6 +356,9 @@ private:
 
   // Head output size from each layer (head1x1.out_channels if active, else bottleneck)
   const int _head_output_size;
+  DSP::LayerObserver _layer_observer = nullptr;
+  void* _layer_observer_context = nullptr;
+  size_t _layer_array_index = 0;
 
   long _get_channels() const;
   // Common processing logic after head inputs are set

--- a/NAM/wavenet/detail.h
+++ b/NAM/wavenet/detail.h
@@ -307,9 +307,6 @@ public:
   void Process(const Eigen::MatrixXf& layer_inputs, const Eigen::MatrixXf& condition,
                const Eigen::MatrixXf& head_inputs, const int num_frames);
 
-  void SetObserver(DSP::LayerObserver observer, void* context,
-                   size_t layerArrayIndex);
-
   /// \brief Get output from last layer (for next layer array)
   ///
   /// Returns the full pre-allocated buffer; only the first num_frames columns
@@ -364,9 +361,6 @@ private:
 
   // Head output size from each layer (head1x1.out_channels if active, else bottleneck)
   const int _head_output_size;
-  DSP::LayerObserver _layer_observer = nullptr;
-  void* _layer_observer_context = nullptr;
-  size_t _layer_array_index = 0;
 
   long _get_channels() const;
   // Common processing logic after head inputs are set

--- a/NAM/wavenet/detail.h
+++ b/NAM/wavenet/detail.h
@@ -3,7 +3,6 @@
 #include "params.h"
 
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -12,6 +11,7 @@
 #include "../conv1d.h"
 #include "../gating_activations.h"
 #include "../film.h"
+#include "../compiler.h"
 
 namespace nam
 {
@@ -60,13 +60,13 @@ public:
       // Validation: if layer1x1 is inactive, bottleneck must equal channels
       if (params.bottleneck != params.channels)
       {
-        throw std::invalid_argument("When layer1x1.active is false, bottleneck (" + std::to_string(params.bottleneck)
-                                    + ") must equal channels (" + std::to_string(params.channels) + ")");
+        NAM_THROW(std::invalid_argument("When layer1x1.active is false, bottleneck (" + std::to_string(params.bottleneck)
+                                    + ") must equal channels (" + std::to_string(params.channels) + ")"));
       }
       // If there's a post-layer1x1 FiLM but no layer1x1, this is redundant--don't allow it
       if (params._layer1x1_post_film_params.active)
       {
-        throw std::invalid_argument("layer1x1_post_film cannot be active when layer1x1 is not active");
+        NAM_THROW(std::invalid_argument("layer1x1_post_film cannot be active when layer1x1 is not active"));
       }
     }
 
@@ -80,7 +80,7 @@ public:
       // If there's a post-head 1x1 FiLM but no head 1x1, this is redundant--don't allow it
       if (params.head1x1_post_film_params.active)
       {
-        throw std::invalid_argument("Do not use post-head 1x1 FiLM if there is no head 1x1");
+        NAM_THROW(std::invalid_argument("Do not use post-head 1x1 FiLM if there is no head 1x1"));
       }
     }
 

--- a/NAM/wavenet/model.cpp
+++ b/NAM/wavenet/model.cpp
@@ -413,6 +413,14 @@ void nam::wavenet::detail::LayerArray::SetMaxBufferSize(const int maxBufferSize)
   this->_head_inputs.resize(this->_head_output_size, maxBufferSize);
 }
 
+void nam::wavenet::detail::LayerArray::SetObserver(
+  const DSP::LayerObserver observer, void* const context, const size_t layerArrayIndex)
+{
+  _layer_observer = observer;
+  _layer_observer_context = context;
+  _layer_array_index = layerArrayIndex;
+}
+
 
 long nam::wavenet::detail::LayerArray::get_receptive_field() const
 {
@@ -462,14 +470,20 @@ void nam::wavenet::detail::LayerArray::ProcessInner(const Eigen::MatrixXf& layer
     if (i == 0)
     {
       // First layer consumes the rechannel output buffer
+      if (_layer_observer != nullptr)
+        _layer_observer(_layer_observer_context, _layer_array_index, i, true);
       this->_layers[i].Process(rechannel_output, condition, num_frames);
     }
     else
     {
       // Subsequent layers consume the full output buffer of the previous layer
       Eigen::MatrixXf& prev_output = this->_layers[i - 1].GetOutputNextLayer();
+      if (_layer_observer != nullptr)
+        _layer_observer(_layer_observer_context, _layer_array_index, i, true);
       this->_layers[i].Process(prev_output, condition, num_frames);
     }
+    if (_layer_observer != nullptr)
+      _layer_observer(_layer_observer_context, _layer_array_index, i, false);
 
     // Accumulate head output from this layer
 #ifdef NAM_USE_INLINE_GEMM
@@ -610,6 +624,7 @@ nam::wavenet::WaveNet::WaveNet(const int in_channels,
         NAM_THROW(std::runtime_error(ss.str().c_str()));
       }
   }
+
   this->set_weights_(weights);
 
   // Finally, figure out how much pre-warming is needed for this model.
@@ -694,6 +709,13 @@ void nam::wavenet::WaveNet::SetPrewarmOnReset(const bool prewarmOnReset)
   DSP::SetPrewarmOnReset(prewarmOnReset);
   if (this->_condition_dsp != nullptr)
     this->_condition_dsp->SetPrewarmOnReset(prewarmOnReset);
+}
+
+void nam::wavenet::WaveNet::SetLayerObserver(const LayerObserver observer,
+                                             void* const context)
+{
+  for (size_t index = 0; index < _layer_arrays.size(); ++index)
+    _layer_arrays[index].SetObserver(observer, context, index);
 }
 
 void nam::wavenet::WaveNet::_process_condition(const int num_frames)

--- a/NAM/wavenet/model.cpp
+++ b/NAM/wavenet/model.cpp
@@ -433,14 +433,6 @@ void nam::wavenet::detail::LayerArray::SetMaxBufferSize(const int maxBufferSize)
   this->_head_inputs.resize(this->_head_output_size, maxBufferSize);
 }
 
-void nam::wavenet::detail::LayerArray::SetObserver(
-  const DSP::LayerObserver observer, void* const context, const size_t layerArrayIndex)
-{
-  _layer_observer = observer;
-  _layer_observer_context = context;
-  _layer_array_index = layerArrayIndex;
-}
-
 long nam::wavenet::detail::LayerArray::get_receptive_field() const
 {
   long result = 0;
@@ -511,20 +503,14 @@ void nam::wavenet::detail::LayerArray::ProcessInner(const Eigen::MatrixXf& layer
     if (i == 0)
     {
       // First layer consumes the rechannel output buffer
-      if (_layer_observer != nullptr)
-        _layer_observer(_layer_observer_context, _layer_array_index, i, true);
       this->_layers[i].Process(rechannel_output, condition, num_frames);
     }
     else
     {
       // Subsequent layers consume the full output buffer of the previous layer
       Eigen::MatrixXf& prev_output = this->_layers[i - 1].GetOutputNextLayer();
-      if (_layer_observer != nullptr)
-        _layer_observer(_layer_observer_context, _layer_array_index, i, true);
       this->_layers[i].Process(prev_output, condition, num_frames);
     }
-    if (_layer_observer != nullptr)
-      _layer_observer(_layer_observer_context, _layer_array_index, i, false);
 
     // Accumulate head output from this layer
 #ifdef NAM_USE_INLINE_GEMM
@@ -750,13 +736,6 @@ void nam::wavenet::WaveNet::SetPrewarmOnReset(const bool prewarmOnReset)
   DSP::SetPrewarmOnReset(prewarmOnReset);
   if (this->_condition_dsp != nullptr)
     this->_condition_dsp->SetPrewarmOnReset(prewarmOnReset);
-}
-
-void nam::wavenet::WaveNet::SetLayerObserver(const LayerObserver observer,
-                                             void* const context)
-{
-  for (size_t index = 0; index < _layer_arrays.size(); ++index)
-    _layer_arrays[index].SetObserver(observer, context, index);
 }
 
 void nam::wavenet::WaveNet::prewarm()

--- a/NAM/wavenet/model.cpp
+++ b/NAM/wavenet/model.cpp
@@ -23,7 +23,7 @@ nam::wavenet::detail::Head::Head(const HeadParams& params)
 , _out_channels(params.out_channels)
 {
   if (params.kernel_sizes.empty())
-    throw std::runtime_error("WaveNet Head: kernel_sizes must be non-empty");
+    NAM_THROW(std::runtime_error("WaveNet Head: kernel_sizes must be non-empty"));
   const size_t n = params.kernel_sizes.size();
   int cin = params.in_channels;
   for (size_t i = 0; i < n; i++)
@@ -31,10 +31,10 @@ nam::wavenet::detail::Head::Head(const HeadParams& params)
     const int cout = (i + 1 == n) ? params.out_channels : params.channels;
     const int k = params.kernel_sizes[i];
     if (k < 1)
-      throw std::runtime_error("WaveNet Head: kernel_sizes entries must be >= 1");
+      NAM_THROW(std::runtime_error("WaveNet Head: kernel_sizes entries must be >= 1"));
     nam::activations::Activation::Ptr act = nam::activations::Activation::get_activation(params.activation_config);
     if (act == nullptr)
-      throw std::runtime_error("WaveNet Head: unsupported activation for post-stack head");
+      NAM_THROW(std::runtime_error("WaveNet Head: unsupported activation for post-stack head"));
     _activations.push_back(std::move(act));
     nam::Conv1D conv;
     conv.set_size_(cin, cout, k, true, 1, 1);
@@ -541,7 +541,7 @@ int wave_net_output_channels(const std::vector<nam::wavenet::LayerArrayParams>& 
                              const bool with_head, const std::optional<nam::wavenet::HeadParams>& head_params)
 {
   if (layer_array_params.empty())
-    throw std::runtime_error("WaveNet requires at least one layer array");
+    NAM_THROW(std::runtime_error("WaveNet requires at least one layer array"));
   if (with_head && head_params.has_value())
     return head_params->out_channels;
   return layer_array_params.back().head_size;
@@ -567,24 +567,24 @@ nam::wavenet::WaveNet::WaveNet(const int in_channels,
       std::stringstream ss;
       ss << "input channels of WaveNet (" << in_channels << ") don't match input channels of condition DSP ("
          << this->_condition_dsp->NumInputChannels() << "!\n";
-      throw std::runtime_error(ss.str().c_str());
+      NAM_THROW(std::runtime_error(ss.str().c_str()));
     }
   }
   if (with_head)
   {
     if (!head_params.has_value())
-      throw std::runtime_error("WaveNet: with_head is true but head configuration is missing");
+      NAM_THROW(std::runtime_error("WaveNet: with_head is true but head configuration is missing"));
     if (head_params->in_channels != layer_array_params.back().head_size)
     {
       std::stringstream ss;
       ss << "WaveNet head in_channels (" << head_params->in_channels << ") must match last layer array head_size ("
          << layer_array_params.back().head_size << ")";
-      throw std::runtime_error(ss.str());
+      NAM_THROW(std::runtime_error(ss.str()));
     }
     this->_post_stack_head = std::make_unique<detail::Head>(*head_params);
   }
   else if (head_params.has_value())
-    throw std::runtime_error("WaveNet: head configuration provided but with_head is false");
+    NAM_THROW(std::runtime_error("WaveNet: head configuration provided but with_head is false"));
 
   for (size_t i = 0; i < layer_array_params.size(); i++)
   {
@@ -597,7 +597,7 @@ nam::wavenet::WaveNet::WaveNet(const int in_channels,
         ss << "condition_size of layer " << i << " (" << layer_array_params[i].condition_size
            << ") doesn't match output channels of condition DSP (" << this->_condition_dsp->NumOutputChannels()
            << "!\n";
-        throw std::runtime_error(ss.str().c_str());
+        NAM_THROW(std::runtime_error(ss.str().c_str()));
       }
     }
     this->_layer_arrays.push_back(nam::wavenet::detail::LayerArray(layer_array_params[i]));
@@ -607,7 +607,7 @@ nam::wavenet::WaveNet::WaveNet(const int in_channels,
         std::stringstream ss;
         ss << "channels of layer " << i << " (" << layer_array_params[i].channels
            << ") doesn't match head_size of preceding layer (" << layer_array_params[i - 1].head_size << "!\n";
-        throw std::runtime_error(ss.str().c_str());
+        NAM_THROW(std::runtime_error(ss.str().c_str()));
       }
   }
   this->set_weights_(weights);
@@ -637,10 +637,10 @@ void nam::wavenet::WaveNet::set_weights_(std::vector<float>& weights)
       if (weights[i] == *it)
       {
         ss << "Weight mismatch: assigned " << i + 1 << " weights, but " << weights.size() << " were provided.";
-        throw std::runtime_error(ss.str().c_str());
+        NAM_THROW(std::runtime_error(ss.str().c_str()));
       }
     ss << "Weight mismatch: provided " << weights.size() << " weights, but the model expects more.";
-    throw std::runtime_error(ss.str().c_str());
+    NAM_THROW(std::runtime_error(ss.str().c_str()));
   }
 }
 
@@ -832,6 +832,7 @@ void nam::wavenet::WaveNet::process(NAM_SAMPLE** input, NAM_SAMPLE** output, con
 }
 
 // Config parser - extracts all configuration from JSON without constructing the DSP
+#if NAM_HAS_JSON
 nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json& config,
                                                             const double expectedSampleRate)
 {
@@ -847,7 +848,7 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
       std::stringstream ss;
       ss << "Condition DSP expected sample rate (" << wc.condition_dsp->GetExpectedSampleRate()
          << ") doesn't match WaveNet expected sample rate (" << expectedSampleRate << "!\n";
-      throw std::runtime_error(ss.str().c_str());
+      NAM_THROW(std::runtime_error(ss.str().c_str()));
     }
   }
 
@@ -886,7 +887,7 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
       const auto& head_json = layer_config["head"];
       if (!head_json.is_object())
       {
-        throw std::runtime_error("Layer array " + std::to_string(i) + ": 'head' must be a JSON object");
+        NAM_THROW(std::runtime_error("Layer array " + std::to_string(i) + ": 'head' must be a JSON object"));
       }
       head_size = head_json.at("out_channels").get<int>();
 
@@ -906,14 +907,14 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
     }
     else
     {
-      throw std::runtime_error("Layer array " + std::to_string(i)
+      NAM_THROW(std::runtime_error("Layer array " + std::to_string(i)
                                + ": expected 'head' object with out_channels, kernel_size, and bias, "
-                                 "or legacy 'head_size' and 'head_bias'");
+                                 "or legacy 'head_size' and 'head_bias'"));
     }
 
     if (head_kernel_size < 1)
     {
-      throw std::runtime_error("Layer array " + std::to_string(i) + ": head.kernel_size must be >= 1");
+      NAM_THROW(std::runtime_error("Layer array " + std::to_string(i) + ": head.kernel_size must be >= 1"));
     }
 
     const auto dilations = layer_config["dilations"];
@@ -925,15 +926,15 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
     std::vector<int> kernel_sizes;
     if (has_kernel_size && has_kernel_sizes)
     {
-      throw std::runtime_error("Layer array " + std::to_string(i)
-                               + ": only one of kernel_size (int) or kernel_sizes (array) may be provided");
+      NAM_THROW(std::runtime_error("Layer array " + std::to_string(i)
+                               + ": only one of kernel_size (int) or kernel_sizes (array) may be provided"));
     }
     else if (has_kernel_sizes)
     {
       const auto& kernel_sizes_json = layer_config["kernel_sizes"];
       if (!kernel_sizes_json.is_array())
       {
-        throw std::runtime_error("Layer array " + std::to_string(i) + ": kernel_sizes must be an array");
+        NAM_THROW(std::runtime_error("Layer array " + std::to_string(i) + ": kernel_sizes must be an array"));
       }
       for (const auto& ks_json : kernel_sizes_json)
       {
@@ -941,9 +942,9 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
       }
       if (kernel_sizes.size() != num_layers)
       {
-        throw std::runtime_error("Layer array " + std::to_string(i) + ": kernel_sizes array size ("
+        NAM_THROW(std::runtime_error("Layer array " + std::to_string(i) + ": kernel_sizes array size ("
                                  + std::to_string(kernel_sizes.size()) + ") must match dilations size ("
-                                 + std::to_string(num_layers) + ")");
+                                 + std::to_string(num_layers) + ")"));
       }
     }
     else if (has_kernel_size)
@@ -953,8 +954,8 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
     }
     else
     {
-      throw std::runtime_error("Layer array " + std::to_string(i)
-                               + ": either kernel_size (int) or kernel_sizes (array) must be provided");
+      NAM_THROW(std::runtime_error("Layer array " + std::to_string(i)
+                               + ": either kernel_size (int) or kernel_sizes (array) must be provided"));
     }
 
     // Parse activation config(s) - support both single config and array
@@ -967,9 +968,9 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
       }
       if (activation_configs.size() != num_layers)
       {
-        throw std::runtime_error("Layer array " + std::to_string(i) + ": activation array size ("
+        NAM_THROW(std::runtime_error("Layer array " + std::to_string(i) + ": activation array size ("
                                  + std::to_string(activation_configs.size()) + ") must match dilations size ("
-                                 + std::to_string(num_layers) + ")");
+                                 + std::to_string(num_layers) + ")"));
       }
     }
     else
@@ -992,7 +993,7 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
       else if (gating_mode_str == "none")
         return GatingMode::NONE;
       else
-        throw std::runtime_error("Invalid gating_mode: " + gating_mode_str);
+        NAM_THROW(std::runtime_error("Invalid gating_mode: " + gating_mode_str));
     };
 
     if (layer_config.find("gating_mode") != layer_config.end())
@@ -1014,9 +1015,9 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
               {
                 if (gating_modes.size() > layer_config["secondary_activation"].size())
                 {
-                  throw std::runtime_error("Layer array " + std::to_string(i)
+                  NAM_THROW(std::runtime_error("Layer array " + std::to_string(i)
                                            + ": secondary_activation array size must be at least "
-                                           + std::to_string(gating_modes.size()));
+                                           + std::to_string(gating_modes.size())));
                 }
                 secondary_activation_configs.push_back(activations::ActivationConfig::from_json(
                   layer_config["secondary_activation"][gating_modes.size() - 1]));
@@ -1042,9 +1043,9 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
         }
         if (gating_modes.size() != num_layers)
         {
-          throw std::runtime_error("Layer array " + std::to_string(i) + ": gating_mode array size ("
+          NAM_THROW(std::runtime_error("Layer array " + std::to_string(i) + ": gating_mode array size ("
                                    + std::to_string(gating_modes.size()) + ") must match dilations size ("
-                                   + std::to_string(num_layers) + ")");
+                                   + std::to_string(num_layers) + ")"));
         }
         // Validate secondary_activation array size if it's an array
         if (layer_config.find("secondary_activation") != layer_config.end()
@@ -1052,9 +1053,9 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
         {
           if (layer_config["secondary_activation"].size() != num_layers)
           {
-            throw std::runtime_error("Layer array " + std::to_string(i) + ": secondary_activation array size ("
+            NAM_THROW(std::runtime_error("Layer array " + std::to_string(i) + ": secondary_activation array size ("
                                      + std::to_string(layer_config["secondary_activation"].size())
-                                     + ") must match dilations size (" + std::to_string(num_layers) + ")");
+                                     + ") must match dilations size (" + std::to_string(num_layers) + ")"));
           }
         }
       }
@@ -1146,8 +1147,8 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
     // Validation: if layer1x1_post_film is active, layer1x1 must also be active
     if (_layer1x1_post_film_params.active && !layer1x1_active)
     {
-      throw std::runtime_error("Layer array " + std::to_string(i)
-                               + ": layer1x1_post_film cannot be active when layer1x1.active is false");
+      NAM_THROW(std::runtime_error("Layer array " + std::to_string(i)
+                               + ": layer1x1_post_film cannot be active when layer1x1.active is false"));
     }
 
     wc.layer_array_params.push_back(nam::wavenet::LayerArrayParams(
@@ -1163,7 +1164,7 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
   wc.in_channels = config.value("in_channels", 1);
 
   if (wc.layer_array_params.empty())
-    throw std::runtime_error("WaveNet config requires at least one layer array");
+    NAM_THROW(std::runtime_error("WaveNet config requires at least one layer array"));
 
   if (wc.with_head)
   {
@@ -1179,7 +1180,7 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
         std::stringstream ss;
         ss << "WaveNet config: head.in_channels (" << legacy_in << ") must equal last layer's head_size (" << implied_in
            << ")";
-        throw std::runtime_error(ss.str());
+        NAM_THROW(std::runtime_error(ss.str()));
       }
     }
     hp.in_channels = implied_in;
@@ -1188,7 +1189,7 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
     hp.kernel_sizes = hj.at("kernel_sizes").get<std::vector<int>>();
     hp.activation_config = nam::activations::ActivationConfig::from_json(hj.at("activation"));
     if (hp.kernel_sizes.empty())
-      throw std::runtime_error("WaveNet config: head.kernel_sizes must be non-empty");
+      NAM_THROW(std::runtime_error("WaveNet config: head.kernel_sizes must be non-empty"));
     wc.head_params = std::move(hp);
   }
   else
@@ -1196,6 +1197,8 @@ nam::wavenet::WaveNetConfig nam::wavenet::parse_config_json(const nlohmann::json
 
   return wc;
 }
+
+#endif
 
 // WaveNetConfig::create()
 std::unique_ptr<nam::DSP> nam::wavenet::WaveNetConfig::create(std::vector<float> weights, double sampleRate)
@@ -1205,6 +1208,7 @@ std::unique_ptr<nam::DSP> nam::wavenet::WaveNetConfig::create(std::vector<float>
                                                  sampleRate);
 }
 
+#if NAM_HAS_JSON
 namespace
 {
 const std::string SLIMMABLE_METHOD = "slice_channels_uniform";
@@ -1221,7 +1225,7 @@ bool config_is_slimmable_wavenet(const nlohmann::json& config)
     if (method != SLIMMABLE_METHOD)
     {
       if (!method.empty())
-        throw std::runtime_error("SlimmableWavenet: unsupported slimmable method '" + method + "'");
+        NAM_THROW(std::runtime_error("SlimmableWavenet: unsupported slimmable method '" + method + "'"));
       continue;
     }
     return true;
@@ -1252,3 +1256,4 @@ namespace
 {
 static nam::ConfigParserHelper _register_WaveNet("WaveNet", nam::wavenet::create_config);
 }
+#endif // NAM_HAS_JSON

--- a/NAM/wavenet/model.h
+++ b/NAM/wavenet/model.h
@@ -61,7 +61,6 @@ public:
   /// \param num_frames Number of frames to process
   void process(NAM_SAMPLE** input, NAM_SAMPLE** output, const int num_frames) override;
 
-  void SetLayerObserver(LayerObserver observer, void* context) override;
   void prewarm() override;
 
   void SetPrewarmOnReset(const bool prewarmOnReset) override;

--- a/NAM/wavenet/model.h
+++ b/NAM/wavenet/model.h
@@ -10,7 +10,10 @@
 #include <Eigen/Dense>
 
 #include "../dsp.h"
-#include "json.hpp"
+
+#if NAM_HAS_JSON
+  #include "json.hpp"
+#endif
 
 #include "detail.h"
 
@@ -138,6 +141,7 @@ struct WaveNetConfig : public ModelConfig
   std::unique_ptr<DSP> create(std::vector<float> weights, double sampleRate) override;
 };
 
+#if NAM_HAS_JSON
 /// \brief Parse WaveNet configuration from JSON
 /// \param config JSON configuration object
 /// \param expectedSampleRate Expected sample rate in Hz (-1.0 if unknown)
@@ -146,6 +150,7 @@ WaveNetConfig parse_config_json(const nlohmann::json& config, const double expec
 
 /// \brief Config parser for ConfigParserRegistry
 std::unique_ptr<ModelConfig> create_config(const nlohmann::json& config, double sampleRate);
+#endif
 
 } // namespace wavenet
 } // namespace nam

--- a/NAM/wavenet/model.h
+++ b/NAM/wavenet/model.h
@@ -61,6 +61,8 @@ public:
   /// \param num_frames Number of frames to process
   void process(NAM_SAMPLE** input, NAM_SAMPLE** output, const int num_frames) override;
 
+  void SetLayerObserver(LayerObserver observer, void* context) override;
+
   void SetPrewarmOnReset(const bool prewarmOnReset) override;
 
   /// \brief Set model weights from a vector

--- a/NAM/wavenet/params.h
+++ b/NAM/wavenet/params.h
@@ -3,7 +3,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-
+#include "../compiler.h"
 #include "../activations.h"
 
 namespace nam
@@ -245,34 +245,34 @@ public:
   {
     if (head_kernel_size < 1)
     {
-      throw std::invalid_argument("LayerArrayParams: head_kernel_size must be >= 1");
+      NAM_THROW(std::invalid_argument("LayerArrayParams: head_kernel_size must be >= 1"));
     }
     const size_t num_layers = dilations.size();
     if (kernel_sizes.empty())
     {
-      throw std::invalid_argument("LayerArrayParams: kernel_sizes must not be empty");
+      NAM_THROW(std::invalid_argument("LayerArrayParams: kernel_sizes must not be empty"));
     }
     if (kernel_sizes.size() != num_layers)
     {
-      throw std::invalid_argument("LayerArrayParams: dilations size (" + std::to_string(num_layers)
-                                  + ") must match kernel_sizes size (" + std::to_string(kernel_sizes.size()) + ")");
+      NAM_THROW(std::invalid_argument("LayerArrayParams: dilations size (" + std::to_string(num_layers)
+                                  + ") must match kernel_sizes size (" + std::to_string(kernel_sizes.size()) + ")"));
     }
     if (activation_configs.size() != num_layers)
     {
-      throw std::invalid_argument("LayerArrayParams: dilations size (" + std::to_string(num_layers)
+      NAM_THROW(std::invalid_argument("LayerArrayParams: dilations size (" + std::to_string(num_layers)
                                   + ") must match activation_configs size (" + std::to_string(activation_configs.size())
-                                  + ")");
+                                  + ")"));
     }
     if (gating_modes.size() != num_layers)
     {
-      throw std::invalid_argument("LayerArrayParams: dilations size (" + std::to_string(num_layers)
-                                  + ") must match gating_modes size (" + std::to_string(gating_modes.size()) + ")");
+      NAM_THROW(std::invalid_argument("LayerArrayParams: dilations size (" + std::to_string(num_layers)
+                                  + ") must match gating_modes size (" + std::to_string(gating_modes.size()) + ")"));
     }
     if (secondary_activation_configs.size() != num_layers)
     {
-      throw std::invalid_argument("LayerArrayParams: dilations size (" + std::to_string(num_layers)
+      NAM_THROW(std::invalid_argument("LayerArrayParams: dilations size (" + std::to_string(num_layers)
                                   + ") must match secondary_activation_configs size ("
-                                  + std::to_string(secondary_activation_configs.size()) + ")");
+                                  + std::to_string(secondary_activation_configs.size()) + ")"));
     }
   }
 

--- a/NAM/wavenet/slimmable.cpp
+++ b/NAM/wavenet/slimmable.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <stdexcept>
 
+#if NAM_HAS_JSON
 namespace nam
 {
 namespace slimmable_wavenet
@@ -88,13 +89,13 @@ int compute_slim_bottleneck(const wavenet::LayerArrayParams& p, int new_channels
 void validate_groups(const wavenet::LayerArrayParams& p)
 {
   if (p.groups_input != 1)
-    throw std::runtime_error("SlimmableWavenet: groups_input > 1 not supported");
+    NAM_THROW(std::runtime_error("SlimmableWavenet: groups_input > 1 not supported"));
   if (p.groups_input_mixin != 1)
-    throw std::runtime_error("SlimmableWavenet: groups_input_mixin > 1 not supported");
+    NAM_THROW(std::runtime_error("SlimmableWavenet: groups_input_mixin > 1 not supported"));
   if (p.layer1x1_params.active && p.layer1x1_params.groups != 1)
-    throw std::runtime_error("SlimmableWavenet: layer1x1 groups > 1 not supported");
+    NAM_THROW(std::runtime_error("SlimmableWavenet: layer1x1 groups > 1 not supported"));
   if (p.head1x1_params.active && p.head1x1_params.groups != 1)
-    throw std::runtime_error("SlimmableWavenet: head1x1 groups > 1 not supported");
+    NAM_THROW(std::runtime_error("SlimmableWavenet: head1x1 groups > 1 not supported"));
 }
 
 // Map ratio [0,1] to a channel count from allowed_channels.
@@ -138,9 +139,9 @@ std::vector<float> extract_slimmed_weights(const std::vector<wavenet::LayerArray
     const auto& p = original_params[arr];
     if (p.head_kernel_size != 1)
     {
-      throw std::runtime_error(
+      NAM_THROW(std::runtime_error(
         "SlimmableWavenet: head rechannel kernel_size must be 1 (slimming with head kernel_size > 1 is not "
-        "implemented)");
+        "implemented)"));
     }
     validate_groups(p);
 
@@ -366,7 +367,7 @@ SlimmableWavenet::SlimmableWavenet(std::vector<wavenet::LayerArrayParams> origin
 , _full_weights(std::move(full_weights))
 {
   if (_per_array_allowed_channels.size() != _original_params.size())
-    throw std::runtime_error("SlimmableWavenet: per_array_allowed_channels size must match number of layer arrays");
+    NAM_THROW(std::runtime_error("SlimmableWavenet: per_array_allowed_channels size must match number of layer arrays"));
 
   // Validate: at least one array must be slimmable
   bool any_slimmable = false;
@@ -380,19 +381,19 @@ SlimmableWavenet::SlimmableWavenet(std::vector<wavenet::LayerArrayParams> origin
       for (size_t j = 1; j < allowed.size(); j++)
       {
         if (allowed[j] <= allowed[j - 1])
-          throw std::runtime_error("SlimmableWavenet: allowed_channels must be sorted ascending");
+          NAM_THROW(std::runtime_error("SlimmableWavenet: allowed_channels must be sorted ascending"));
       }
       // Validate last entry matches full channel count
       if (allowed.back() != _original_params[i].channels)
-        throw std::runtime_error(
-          "SlimmableWavenet: last allowed_channels entry must equal the full channel count for that array");
+        NAM_THROW(std::runtime_error(
+          "SlimmableWavenet: last allowed_channels entry must equal the full channel count for that array"));
     }
   }
   if (!any_slimmable)
-    throw std::runtime_error("SlimmableWavenet: at least one layer array must have allowed_channels");
+    NAM_THROW(std::runtime_error("SlimmableWavenet: at least one layer array must have allowed_channels"));
 
   if (with_head)
-    throw std::runtime_error("SlimmableWavenet: post-stack head is not supported");
+    NAM_THROW(std::runtime_error("SlimmableWavenet: post-stack head is not supported"));
 
   // Build with full channel counts as default (ratio=1.0)
   std::vector<int> full_channels(_original_params.size());
@@ -556,7 +557,7 @@ std::unique_ptr<DSP> SlimmableWavenetConfig::create(std::vector<float> weights, 
       const auto& slim_cfg = lc["slimmable"];
       const std::string method = slim_cfg.value("method", "");
       if (method != "slice_channels_uniform")
-        throw std::runtime_error("SlimmableWavenet: unsupported slimmable method '" + method + "'");
+        NAM_THROW(std::runtime_error("SlimmableWavenet: unsupported slimmable method '" + method + "'"));
       if (slim_cfg.find("kwargs") != slim_cfg.end()
           && slim_cfg["kwargs"].find("allowed_channels") != slim_cfg["kwargs"].end())
       {
@@ -594,3 +595,4 @@ std::unique_ptr<ModelConfig> create_config(const nlohmann::json& config, double 
 
 } // namespace slimmable_wavenet
 } // namespace nam
+#endif // NAM_HAS_JSON

--- a/NAM/wavenet/slimmable.h
+++ b/NAM/wavenet/slimmable.h
@@ -3,6 +3,10 @@
 #include <memory>
 #include <vector>
 
+#include "../compiler.h"
+
+#if NAM_HAS_JSON
+
 // std::atomic<std::shared_ptr<T>> requires C++20 library support (libstdc++ >= GCC 12).
 // Where it is unavailable -- libc++ (any version so far) and older libstdc++ such as the
 // one shipped with GCC 9 -- fall back to the deprecated std::atomic_* free-function
@@ -61,6 +65,7 @@ public:
   void SetPrewarmOnReset(const bool prewarmOnReset) override;
   void SetSlimmableSize(const double val) override;
   std::vector<double> GetSlimmableSizeBreakpoints() const override;
+  SlimmableModel* GetSlimmableModel() override { return this; }
 
 protected:
   int GetPrewarmSamples() override { return 0; }
@@ -118,3 +123,5 @@ std::unique_ptr<ModelConfig> create_config(const nlohmann::json& config, double 
 
 } // namespace slimmable_wavenet
 } // namespace nam
+
+#endif // NAM_HAS_JSON

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -20,8 +20,6 @@ add_executable(loadmodel loadmodel.cpp ${NAM_SOURCES})
 add_executable(benchmodel benchmodel.cpp ${NAM_SOURCES})
 add_executable(render render.cpp ${NAM_SOURCES} ${AUDIO_DSP_TOOLS_WAV_SOURCES})
 target_compile_features(render PUBLIC cxx_std_20)
-# AudioDSPTools wav.cpp has sign-compare issues; don't fail build
-set_source_files_properties(${AUDIO_DSP_TOOLS_WAV_SOURCES} PROPERTIES COMPILE_FLAGS "-Wno-error")
 set_target_properties(render PROPERTIES
 	CXX_VISIBILITY_PRESET hidden
 	INTERPROCEDURAL_OPTIMIZATION TRUE
@@ -36,6 +34,8 @@ if (MSVC)
 		"$<$<CONFIG:RELEASE>:/O2>"
 	)
 else()
+	# AudioDSPTools wav.cpp has sign-compare issues; don't fail build
+	set_source_files_properties(${AUDIO_DSP_TOOLS_WAV_SOURCES} PROPERTIES COMPILE_FLAGS "-Wno-error")
 	target_compile_options(render PRIVATE
 		-Wall -Wextra -Wpedantic -Wstrict-aliasing -Wunreachable-code -Weffc++ -Wno-unused-parameter
 		"$<$<CONFIG:DEBUG>:-Og;-ggdb;-Werror>"
@@ -61,11 +61,24 @@ else()
 		"$<$<CONFIG:DEBUG>:-Og;-ggdb;-Werror>"
 		"$<$<CONFIG:RELEASE>:-Ofast>"
 	)
+	# Compile run_tests without optimizations to ensure allocation tracking works correctly
+	# Also ensure assertions are enabled (NDEBUG is not defined) so tests actually run
+	set_target_properties(run_tests PROPERTIES COMPILE_OPTIONS "-O0")
+	# There's an error in eigen's
+	# /Users/steve/src/NeuralAmpModelerCore/Dependencies/eigen/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+	# Don't let this break my build on debug:
+	set_source_files_properties(../NAM/dsp.cpp PROPERTIES COMPILE_FLAGS "-Wno-error")
+	set_source_files_properties(../NAM/conv1d.cpp PROPERTIES COMPILE_FLAGS "-Wno-error")
 endif()
 add_executable(run_tests run_tests.cpp test/allocation_tracking.cpp ${NAM_SOURCES})
-# Compile run_tests without optimizations to ensure allocation tracking works correctly
-# Also ensure assertions are enabled (NDEBUG is not defined) so tests actually run
-set_target_properties(run_tests PROPERTIES COMPILE_OPTIONS "-O0")
+
+# Only allow allocation tracking on Linux and macOS. Not on Windows and not on embedded.
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+	target_compile_definitions(run_tests PRIVATE NAM_ALLOC_TRACKING_ENABLED=1)
+else()
+	target_compile_definitions(run_tests PRIVATE NAM_ALLOC_TRACKING_ENABLED=0)
+endif()
+
 # Ensure assertions are enabled for run_tests by removing NDEBUG if it was set
 # Release/RelWithDebInfo/MinSizeRel build types automatically define NDEBUG
 # We use a compile option to undefine it, which works on GCC, Clang, and MSVC
@@ -106,9 +119,3 @@ else()
 		"$<$<CONFIG:RELEASE>:-Ofast>"
 	)
 endif()
-
-# There's an error in eigen's
-# /Users/steve/src/NeuralAmpModelerCore/Dependencies/eigen/Eigen/src/Core/products/GeneralBlockPanelKernel.h
-# Don't let this break my build on debug:
-set_source_files_properties(../NAM/dsp.cpp PROPERTIES COMPILE_FLAGS "-Wno-error")
-set_source_files_properties(../NAM/conv1d.cpp PROPERTIES COMPILE_FLAGS "-Wno-error")

--- a/tools/bench_a2_fast.cpp
+++ b/tools/bench_a2_fast.cpp
@@ -12,9 +12,9 @@
 
 #if defined(NAM_ENABLE_A2_FAST)
 
+  #include <cmath>
   #include <algorithm>
   #include <chrono>
-  #include <cmath>
   #include <cstdlib>
   #include <cstring>
   #include <filesystem>

--- a/tools/test/allocation_tracking.cpp
+++ b/tools/test/allocation_tracking.cpp
@@ -17,6 +17,7 @@ void (*original_free)(void*) = nullptr;
 void* (*original_realloc)(void*, size_t) = nullptr;
 } // namespace allocation_tracking
 
+#if NAM_ALLOC_TRACKING_ENABLED
 // Override malloc/free to track Eigen allocations (Eigen uses malloc directly)
 extern "C" {
 void* malloc(size_t size)
@@ -88,3 +89,4 @@ void operator delete[](void* ptr) noexcept
     ++allocation_tracking::g_deallocation_count;
   std::free(ptr);
 }
+#endif

--- a/tools/test/allocation_tracking.h
+++ b/tools/test/allocation_tracking.h
@@ -6,10 +6,13 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <dlfcn.h>
 #include <functional>
 #include <iostream>
 #include <new>
+
+#if NAM_ALLOC_TRACKING_ENABLED
+#include <dlfcn.h>
+#endif
 
 // Allocation tracking globals
 namespace allocation_tracking
@@ -53,6 +56,13 @@ void run_allocation_test(std::function<void()> setup, TestFunc test, std::functi
   if (teardown)
     teardown();
 
+#if !NAM_ALLOC_TRACKING_ENABLED
+  (void)expected_allocations;
+  (void)expected_deallocations;
+  (void)test_name;
+  return;
+#endif
+
   // Assert expected allocations/deallocations
   if (g_allocation_count != expected_allocations || g_deallocation_count != expected_deallocations)
   {
@@ -94,6 +104,11 @@ void run_allocation_test_expect_allocations(std::function<void()> setup, TestFun
   // Run teardown if provided
   if (teardown)
     teardown();
+
+#if !NAM_ALLOC_TRACKING_ENABLED
+  (void)test_name;
+  return;
+#endif
 
   // Assert that allocations occurred (this test verifies our tracking works)
   if (g_allocation_count == 0 && g_deallocation_count == 0)

--- a/tools/test/test_a2_fast.cpp
+++ b/tools/test/test_a2_fast.cpp
@@ -6,9 +6,9 @@
 
 #if defined(NAM_ENABLE_A2_FAST)
 
+  #include <cmath>
   #include <algorithm>
   #include <cassert>
-  #include <cmath>
   #include <cstdint>
   #include <iostream>
   #include <memory>

--- a/tools/test/test_lstm.cpp
+++ b/tools/test/test_lstm.cpp
@@ -1,8 +1,8 @@
 // Tests for LSTM
 
+#include <cmath>
 #include <Eigen/Dense>
 #include <cassert>
-#include <cmath>
 #include <iostream>
 #include <vector>
 

--- a/tools/test/test_wavenet_configurable_gating.cpp
+++ b/tools/test/test_wavenet_configurable_gating.cpp
@@ -299,11 +299,17 @@ public:
 
     // Set some weights to make the layers produce different outputs
     std::vector<float> weights;
-    // Add weights for conv layer (simplified - just enough to make it non-zero)
-    const int conv_weights = channels * 2 * bottleneck * kernelSize; // 2*bottleneck for gated
+    // Add weights for conv layer (2*bottleneck outputs for gated), including bias
+    const int conv_out_channels = 2 * bottleneck;
+    const int conv_weights = channels * conv_out_channels * kernelSize;
+    const int conv_bias = conv_out_channels;
     for (int i = 0; i < conv_weights; i++)
     {
       weights.push_back(0.1f * i);
+    }
+    for (int i = 0; i < conv_bias; i++)
+    {
+      weights.push_back(0.01f * i);
     }
     // Add weights for input mixin
     const int mixin_weights = conditionSize * 2 * bottleneck;
@@ -311,11 +317,16 @@ public:
     {
       weights.push_back(0.05f * i);
     }
-    // Add weights for 1x1 conv
+    // Add weights for 1x1 conv, including bias
     const int conv1x1_weights = bottleneck * channels;
+    const int conv1x1_bias = channels;
     for (int i = 0; i < conv1x1_weights; i++)
     {
       weights.push_back(0.02f * i);
+    }
+    for (int i = 0; i < conv1x1_bias; i++)
+    {
+      weights.push_back(0.03f * i);
     }
 
     // Set weights for all layers
@@ -327,6 +338,8 @@ public:
 
     weights_iter = weights.begin();
     layer_relu.set_weights_(weights_iter);
+
+    assert(weights_iter == weights.end());
 
     // Create some test input data
     Eigen::MatrixXf input(channels, num_frames);


### PR DESCRIPTION
PR built on top of the Windows compatibility changes from [this PR](https://github.com/sdatkinson/NeuralAmpModelerCore/pull/309).
Adding some flexibility for embedded targets, where things such as mutex, JSON parsing, exceptions and file system... are not available. Hence introducing `NAM_NO_EXCEPTIONS`, `NAM_NO_MUTEX`, `NAM_NO_JSON`, `NAM_NO_FILESYSTEM`
Optimizing `_ring_write()` with lazy tail mirroring. Previously ,it copied the entire ring prefix into the mirror on every layer and every block. Most blocks do not wrap the ring, so that copy is unnecessary. This saves ~1.5% CPU on cortex M7 and is a generic implementation for all platforms.